### PR TITLE
0010

### DIFF
--- a/discogs_alert/__main__.py
+++ b/discogs_alert/__main__.py
@@ -154,7 +154,7 @@ logger = logging.getLogger(__name__)
     hidden=True,
     help="use flag if you want to immediately run the program (to test that your wantlist is correct)",
 )
-@click.version_option("0.0.7")
+@click.version_option("0.0.10")
 def main(
     discogs_token,
     pushbullet_token,
@@ -212,7 +212,6 @@ def main(
     )
 
     if test:
-        args[-1] = True
         da_loop.loop(*args)
     else:
         schedule.every(int(60 / frequency)).minutes.do(lambda: da_loop.loop(*args))

--- a/discogs_alert/loop.py
+++ b/discogs_alert/loop.py
@@ -132,5 +132,4 @@ def loop(
     except:
         logger.info("Exception: this might be a real exception, but we're continuing anyway", exc_info=True)
 
-    if verbose:
-        logger.info(f"\t took {time.time() - start_time}")
+    logger.info(f"\t took {time.time() - start_time}")

--- a/discogs_alert/loop.py
+++ b/discogs_alert/loop.py
@@ -1,6 +1,8 @@
 import json
 import logging
+import requests
 import time
+from collections import defaultdict
 from typing import List, Optional
 
 import dacite
@@ -56,6 +58,14 @@ def loop(
         client_anon = da_client.AnonClient(user_agent)
         user_token_client = da_client.UserTokenClient(user_agent, discogs_token)
 
+        # get the complete list of previous pushes
+        headers = {"Authorization": "Bearer " + pushbullet_token, "Content-Type": "application/json"}
+        url = "https://api.pushbullet.com/v2/pushes"
+        resp = requests.get(url, headers=headers)
+        pushes_dict = defaultdict(list)
+        for p in resp.json().get("pushes"):
+            pushes_dict[p["title"]].append(p["body"])
+
         for release in load_wantlist(list_id, user_token_client, wantlist_path):
             valid_listings: List[da_types.Listing] = []
 
@@ -68,20 +78,22 @@ def loop(
 
                 # if listing is definitely unavailable, move to the next listing
                 if listing.is_definitely_unavailable(country):
-                    logger.info(
-                        f"Listing found that's unavailable in {country}:\n"
-                        f"\tRelease: {release.display_title}\n"
-                        f"\tListing: {listing.url}"
-                    )
+                    if verbose:
+                        logger.info(
+                            f"Listing found that's unavailable in {country}:\n"
+                            f"\tRelease: {release.display_title}\n"
+                            f"\tListing: {listing.url}"
+                        )
                     continue
 
                 # if seller, sleeve, and media conditions are not satisfied, move to the next listing
                 if not da_util.conditions_satisfied(listing, release, seller_filters, record_filters):
-                    logger.info(
-                        f"Listing found that doesn't satisfy conditions:\n"
-                        f"\tRelease: {release.display_title}\n"
-                        f"\tListing: {listing.url}"
-                    )
+                    if verbose:
+                        logger.info(
+                            f"Listing found that doesn't satisfy conditions:\n"
+                            f"\tRelease: {release.display_title}\n"
+                            f"\tListing: {listing.url}"
+                        )
                     continue
 
                 # if the price is above our threshold (after converting to the base currency),
@@ -90,11 +102,12 @@ def loop(
                 if (isinstance(listing.price, bool) and not listing.price) or listing.price_is_above_threshold(
                     release.price_threshold
                 ):
-                    logger.info(
-                        f"Listing found that's above the price threshold:\n"
-                        f"\tRelease: {release.display_title}\n"
-                        f"\tListing: {listing.url}"
-                    )
+                    if verbose:
+                        logger.info(
+                            f"Listing found that's above the price threshold:\n"
+                            f"\tRelease: {release.display_title}\n"
+                            f"\tListing: {listing.url}"
+                        )
                     continue
 
                 valid_listings.append(listing)
@@ -102,12 +115,13 @@ def loop(
             # if we found something, send notification
             if len(valid_listings) > 0:
                 # TODO: send a push for _each_ valid listing if there are somehow more than one
-                da_notify.send_pushbullet_push(
-                    token=pushbullet_token,
-                    message_title=f"Now For Sale: {release.display_title}",
-                    message_body=f"Listing available: {valid_listings[0].url}",
-                    verbose=verbose,
-                )
+                message_title = f"Now For Sale: {release.display_title}"
+                message_body = f"Listing available: {valid_listings[0].url}"
+                if message_title not in pushes_dict or message_body not in pushes_dict[message_title]:
+                    print(f"{message_title} — {message_body}")
+                    da_notify.send_pushbullet_push(
+                        token=pushbullet_token, message_title=message_title, message_body=message_body, verbose=verbose
+                    )
 
     except ConnectionError:
         logger.info("ConnectionError: looping will continue as usual", exc_info=True)

--- a/discogs_alert/notify.py
+++ b/discogs_alert/notify.py
@@ -21,26 +21,14 @@ def send_pushbullet_push(token: str, message_title: str, message_body: str, verb
         headers = {"Authorization": "Bearer " + token, "Content-Type": "application/json"}
         message = {"type": "note", "title": message_title, "body": message_body}
         url = "https://api.pushbullet.com/v2/pushes"
-
-        # work out if there is an existing, identical push
-        resp = requests.get(url, headers=headers)
-        have_already_sent = False
-        for p in resp.json().get("pushes"):
-            if p.get("title") == message.get("title") and p.get("body") == message.get("body"):
-                have_already_sent = True
-                break
-
-        # if not, send one
-        if not have_already_sent:
-            if verbose:
-                logger.info("sending notification")
-            resp = requests.post(url, data=json.dumps(message), headers=headers)
-            if resp.status_code != 200:
-                logger.error(f"error {resp.status_code} sending pushbullet notification: {resp.content}")
-                return False
-            else:
-                return True
-        return True
+        if verbose:
+            logger.info("sending notification")
+        resp = requests.post(url, data=json.dumps(message), headers=headers)
+        if resp.status_code != 200:
+            logger.error(f"error {resp.status_code} sending pushbullet notification: {resp.content}")
+            return False
+        else:
+            return True
     except:
         # TODO: what type of exception is thrown here ?
         logger.error(f"Exception sending pushbullet push", exc_info=True)

--- a/discogs_alert/scrape.py
+++ b/discogs_alert/scrape.py
@@ -46,9 +46,11 @@ def scrape_listings_from_marketplace(response_content: str) -> da_types.Listings
 
         item_condition_para = item_desc_cell.find("p", class_="item_condition")
 
-        # extract media condition
-        media_condition_tooltips = item_condition_para.find(class_="media-condition-tooltip")
-        media_condition = media_condition_tooltips.get("data-condition")
+        # extract media condition (via ignoring the context of the new media condition tooltip)
+        media_condition_span = item_condition_para.find_all("span")[2]
+        media_condition_tooltip_span = media_condition_span.find("span", class_="has-tooltip")
+        media_condition_tooltip_span.replace_with("")
+        media_condition = media_condition_span.text.strip()
         listing["media_condition"] = da_types.CONDITION_PARSER[media_condition]
 
         # extract sleeve condition
@@ -57,7 +59,8 @@ def scrape_listings_from_marketplace(response_content: str) -> da_types.Listings
             sleeve_condition = sleeve_condition_spans.contents[0].strip()
             sleeve_condition = da_types.CONDITION_PARSER[sleeve_condition]
         else:
-            sleeve_condition = None
+            # sometimes the sleeve condition isn't listed => ungraded
+            sleeve_condition = da_types.CONDITION.NOT_GRADED
         listing["sleeve_condition"] = sleeve_condition
 
         # the seller's comment is the last paragraph (doesn't have a nice class name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "discogs_alert"
-version = "0.0.9"
+version = "0.0.10"
 description = "Configurable, real-time alerts for your discogs wantlist"
 license = "GPL-3.0-only"
 authors = ["mhsb <michael.h.s.ball@gmail.com>"]


### PR DESCRIPTION
- changed the loop to ping the pushbullet API less frequently to avoid hitting limits (by querying past pushes once per loop rather than once per release)
- hid more logs behind the `verbose` flag so the default operation is clean
- fixed two separate parsing bugs, introduced due to changes on the Discogs marketplace:
    - the media condition elements changed their structure
    - the sleeve condition is now sometimes not displayed