### PR TITLE
Fix docker, fix selenium deprecations

### DIFF
--- a/discogs_alert/client.py
+++ b/discogs_alert/client.py
@@ -12,7 +12,7 @@ from typing import Union
 
 import requests
 from fake_useragent import UserAgent
-from selenium import webdriver
+from webdriver.chromium.webdriver import ChromiumDriver, Service, ChromeOptions
 from webdriver_manager.chrome import ChromeDriverManager
 from webdriver_manager.core.utils import ChromeType
 
@@ -106,7 +106,7 @@ class AnonClient(Client):
 
         self.user_agent = UserAgent()  # can pull up-to-date user agents from any modern browser
 
-        self.options = webdriver.ChromeOptions()
+        options = ChromeOptions()
         options_arguments = [
             "--no-sandbox",
             "--disable-gpu",
@@ -119,9 +119,9 @@ class AnonClient(Client):
         for argument in options_arguments:
             self.options.add_argument(argument)
 
-        service_log_path = "/dev/null" if sys.platform in {"linux", "linux2", "darwin"} else "NUL"
-        self.driver = webdriver.Chrome(
-            self.get_driver_path(), options=self.options, service_log_path=service_log_path
+        log_path = "/dev/null" if sys.platform in {"linux", "linux2", "darwin"} else "NUL"
+        self.driver = ChromiumDriver(
+            service=Service(self.get_driver_path(), log_path=log_path), options=options
         )  # disable logs
 
     def get_driver_path(self):

--- a/discogs_alert/client.py
+++ b/discogs_alert/client.py
@@ -12,7 +12,7 @@ from typing import Union
 
 import requests
 from fake_useragent import UserAgent
-from webdriver.chromium.webdriver import ChromiumDriver, Service, ChromeOptions
+from selenium.chromium.webdriver import ChromiumDriver, Service, ChromeOptions
 from webdriver_manager.chrome import ChromeDriverManager
 from webdriver_manager.core.utils import ChromeType
 
@@ -108,7 +108,6 @@ class AnonClient(Client):
 
         options = ChromeOptions()
         options_arguments = [
-            "--no-sandbox",
             "--disable-gpu",
             "--disable-dev-shm-usage",
             "--disable-infobars",
@@ -116,6 +115,9 @@ class AnonClient(Client):
             "--incognito",
             f"--user-agent={self.user_agent.random}",  # initialize with random user-agent
         ]
+        if os.geteuid() == 0:
+            # running as root
+            options_arguments.append("--no-sandbox")
         for argument in options_arguments:
             self.options.add_argument(argument)
 

--- a/discogs_alert/client.py
+++ b/discogs_alert/client.py
@@ -119,7 +119,7 @@ class AnonClient(Client):
             # running as root
             options_arguments.append("--no-sandbox")
         for argument in options_arguments:
-            self.options.add_argument(argument)
+            options.add_argument(argument)
 
         log_path = "/dev/null" if sys.platform in {"linux", "linux2", "darwin"} else "NUL"
         self.driver = ChromiumDriver(

--- a/discogs_alert/client.py
+++ b/discogs_alert/client.py
@@ -12,7 +12,7 @@ from typing import Union
 
 import requests
 from fake_useragent import UserAgent
-from selenium.chromium.webdriver import ChromiumDriver, Service, ChromeOptions
+from selenium.webdriver.chromium.webdriver import ChromiumDriver, Service, ChromeOptions
 from webdriver_manager.chrome import ChromeDriverManager
 from webdriver_manager.core.utils import ChromeType
 

--- a/discogs_alert/client.py
+++ b/discogs_alert/client.py
@@ -12,7 +12,7 @@ from typing import Union
 
 import requests
 from fake_useragent import UserAgent
-from selenium.webdriver.chromium.webdriver import ChromiumDriver
+from selenium import webdriver
 from selenium.webdriver.chromium.service import ChromiumService
 from selenium.webdriver.chromium.options import ChromiumOptions
 from webdriver_manager.chrome import ChromeDriverManager
@@ -125,7 +125,7 @@ class AnonClient(Client):
         for argument in options_arguments:
             options.add_argument(argument)
 
-        self.driver = ChromiumDriver(service=service, options=options)
+        self.driver = webdriver.Chrome(service=service, options=options)
 
     def get_driver_path(self):
         try:

--- a/discogs_alert/client.py
+++ b/discogs_alert/client.py
@@ -106,7 +106,7 @@ class AnonClient(Client):
 
         self.options = webdriver.ChromeOptions()
         options_arguments = [
-            "--remote-debugging-port=9222",
+            "--no-sandbox",
             "--disable-gpu",
             "--disable-dev-shm-usage",
             "--disable-infobars",

--- a/discogs_alert/client.py
+++ b/discogs_alert/client.py
@@ -106,7 +106,7 @@ class AnonClient(Client):
 
         self.options = webdriver.ChromeOptions()
         options_arguments = [
-            "--remote-debugging-port=9222"
+            "--remote-debugging-port=9222",
             "--disable-gpu",
             "--disable-dev-shm-usage",
             "--disable-infobars",

--- a/discogs_alert/client.py
+++ b/discogs_alert/client.py
@@ -13,8 +13,8 @@ from typing import Union
 import requests
 from fake_useragent import UserAgent
 from selenium import webdriver
-from selenium.webdriver.chromium.service import ChromiumService
 from selenium.webdriver.chromium.options import ChromiumOptions
+from selenium.webdriver.chromium.service import ChromiumService
 from webdriver_manager.chrome import ChromeDriverManager
 from webdriver_manager.core.utils import ChromeType
 
@@ -135,7 +135,7 @@ class AnonClient(Client):
         except subprocess.CalledProcessError:
             # will install latest chromedriver binary regardless of currently installed chromium version
             return ChromeDriverManager(chrome_type=ChromeType.CHROMIUM).install()
-        
+
     def get_marketplace_listings(self, release_id: int) -> da_entities.Listings:
         """Get list of listings currently for sale for particular release (by release's discogs ID)"""
 

--- a/discogs_alert/client.py
+++ b/discogs_alert/client.py
@@ -12,7 +12,9 @@ from typing import Union
 
 import requests
 from fake_useragent import UserAgent
-from selenium.webdriver.chromium.webdriver import ChromiumDriver, Service, ChromeOptions
+from selenium.webdriver.chromium.webdriver import ChromiumDriver
+from selenium.webdriver.chromium.service import ChromiumService
+from selenium.webdriver.chromium.options import ChromiumOptions
 from webdriver_manager.chrome import ChromeDriverManager
 from webdriver_manager.core.utils import ChromeType
 
@@ -106,7 +108,9 @@ class AnonClient(Client):
 
         self.user_agent = UserAgent()  # can pull up-to-date user agents from any modern browser
 
-        options = ChromeOptions()
+        log_path = "/dev/null" if sys.platform in {"linux", "linux2", "darwin"} else "NUL"  # disable logs
+        service = ChromiumService(self.get_driver_path(), log_path=log_path)
+        options = ChromiumOptions()
         options_arguments = [
             "--disable-gpu",
             "--disable-dev-shm-usage",
@@ -121,18 +125,12 @@ class AnonClient(Client):
         for argument in options_arguments:
             options.add_argument(argument)
 
-        log_path = "/dev/null" if sys.platform in {"linux", "linux2", "darwin"} else "NUL"
-        self.driver = ChromiumDriver(
-            service=Service(self.get_driver_path(), log_path=log_path), options=options
-        )  # disable logs
+        self.driver = ChromiumDriver(service=service, options=options)
 
     def get_driver_path(self):
         try:
             # to install both chromium binary and the matching chromedriver binary:
-            # debian:
             # apt-get install chromium-driver
-            # ubuntu:
-            # apt-get install chromium-chromedriver
             return subprocess.check_output(['which', 'chromedriver'])
         except subprocess.CalledProcessError:
             # will install latest chromedriver binary regardless of currently installed chromium version

--- a/discogs_alert/client.py
+++ b/discogs_alert/client.py
@@ -106,6 +106,7 @@ class AnonClient(Client):
 
         self.options = webdriver.ChromeOptions()
         options_arguments = [
+            "--remote-debugging-port=9222"
             "--disable-gpu",
             "--disable-dev-shm-usage",
             "--disable-infobars",

--- a/discogs_alert/client.py
+++ b/discogs_alert/client.py
@@ -131,7 +131,7 @@ class AnonClient(Client):
         try:
             # to install both chromium binary and the matching chromedriver binary:
             # apt-get install chromium-driver
-            return subprocess.check_output(['which', 'chromedriver'])
+            return subprocess.check_output(['which', 'chromedriver']).decode().strip()
         except subprocess.CalledProcessError:
             # will install latest chromedriver binary regardless of currently installed chromium version
             return ChromeDriverManager(chrome_type=ChromeType.CHROMIUM).install()

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,11 +35,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends chromium-driver
 FROM python-base as final
 
 # copy everything we need & install `discogs_alert` from whl
-COPY --from=builder /venv /home/discogs_alert/venv
+COPY --from=builder /venv /venv
 COPY --from=builder /dist .
 COPY --from=builder /usr/bin/chromium /usr/bin/chromium
 COPY --from=builder /usr/bin/chromedriver /usr/bin/chromedriver
-RUN . /home/discogs_alert/venv/bin/activate && pip install *.whl
+RUN . /venv/bin/activate && pip install *.whl
 
 # run entrypoint
 COPY ./docker/docker-entrypoint.sh ./

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,22 +27,18 @@ RUN poetry install --no-dev --no-root
 COPY . .
 RUN poetry build
 
-# install chromium
-RUN apt-get update && apt-get install -y chromium
+# install chromium binary and matching chromedriver binary
+RUN apt-get update && apt-get install -y --no-install-recommends chromium-driver
 
 
 # create lightweight 'final' stage with which to run discogs alert
 FROM python-base as final
 
-# Add `discogs_alert` user and setup home dir.
-RUN useradd -ms /bin/bash discogs_alert
-USER discogs_alert
-WORKDIR /home/discogs_alert
-
 # copy everything we need & install `discogs_alert` from whl
 COPY --from=builder /venv /home/discogs_alert/venv
 COPY --from=builder /dist .
 COPY --from=builder /usr/bin/chromium /usr/bin/chromium
+COPY --from=builder /usr/bin/chromedriver /usr/bin/chromedriver
 RUN . /home/discogs_alert/venv/bin/activate && pip install *.whl
 
 # run entrypoint


### PR DESCRIPTION
re: #43 I didn't manage to get docker running as user either

deprecations: https://stackoverflow.com/a/70099102/5511061

tested using [simplified Dockerfile](https://gist.github.com/ddelange/b9ef356719c6b08ac28aeab5ef372605)

webdriver_manager does not check chromium version (on bullseye apt it's v110):
```
selenium.common.exceptions.SessionNotCreatedException: Message: session not created: This version of ChromeDriver only supports Chrome version 111
Current browser version is 110.0.5481.177 with binary path /usr/bin/chromium
```

so now getting the matching versions using apt directly