### PR TITLE
Bump deps to current major versions, fix breaking imports

### DIFF
--- a/discogs_alert/client.py
+++ b/discogs_alert/client.py
@@ -16,7 +16,7 @@ from selenium import webdriver
 from selenium.webdriver.chromium.options import ChromiumOptions
 from selenium.webdriver.chromium.service import ChromiumService
 from webdriver_manager.chrome import ChromeDriverManager
-from webdriver_manager.core.utils import ChromeType
+from webdriver_manager.core.os_manager import ChromeType
 
 from discogs_alert import entities as da_entities, scrape as da_scrape
 
@@ -108,18 +108,18 @@ class AnonClient(Client):
 
         self.user_agent = UserAgent()  # can pull up-to-date user agents from any modern browser
 
-        log_path = "/dev/null" if sys.platform in {"linux", "linux2", "darwin"} else "NUL"  # disable logs
-        service = ChromiumService(self.get_driver_path(), log_path=log_path)
+        log_output = "/dev/null" if sys.platform in {"linux", "linux2", "darwin"} else "NUL"  # disable logs
+        service = ChromiumService(self.get_driver_path(), log_output=log_output)
         options = ChromiumOptions()
         options_arguments = [
             "--disable-gpu",
             "--disable-dev-shm-usage",
             "--disable-infobars",
-            "--headless",
+            "--headless=new",
             "--incognito",
             f"--user-agent={self.user_agent.random}",  # initialize with random user-agent
         ]
-        if os.geteuid() == 0:
+        if hasattr(os, "geteuid") and os.geteuid() == 0:
             # running as root
             options_arguments.append("--no-sandbox")
         for argument in options_arguments:

--- a/discogs_alert/scrape.py
+++ b/discogs_alert/scrape.py
@@ -109,7 +109,9 @@ def scrape_listings_from_marketplace(response_content: str, release_id: int) -> 
             listing["seller_avg_rating"] = float(seller_avg_rating_elt.strip().split("%")[0])
 
         try:
-            listing["seller_ships_from"] = seller_info_cell.find("span", text="Ships From:").parent.contents[1].strip()
+            listing["seller_ships_from"] = (
+                seller_info_cell.find("span", string="Ships From:").parent.contents[1].strip()
+            )
         except IndexError:
             # if we get an IndexError here it means the listing had no "Ships From:" country, => we don't continue
             # parsing. The only times I've seen such listings in the past were scams...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,22 +12,22 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.10"
-beautifulsoup4 = "^4.11.2"
-click = "^8.1.3"
-dacite = "^1.8.0"
-fake-useragent = "^1.1.1"
-pre-commit = "^2.20.0"
-requests = "^2.28.2"
-ruff = "^0.0.253"
-schedule = "^1.1.0"
-selenium = "^4.8.2"
-tox = "^4.4.5"
-webdriver-manager = "^3.8.5"
+beautifulsoup4 = "^4.12"
+click = "^8.1"
+dacite = "^1.8"
+fake-useragent = "^1.5"
+requests = "^2.32"
+schedule = "^1.2"
+selenium = "^4.25"
+webdriver-manager = "^4.0"
 
 [tool.poetry.dev-dependencies]
-pytest = "^7.2.1"
-pytest-sugar = "^0.9.6"
-pytest-cov = "^4.1.0"
+pre-commit = "^3.7"
+pytest = "^8.2"
+pytest-cov = "^5.0"
+pytest-sugar = "^1.0"
+ruff = "^0.6"
+tox = "^4.15"
 
 [build-system]
 requires = ["poetry-core>=1.1.0"]
@@ -45,17 +45,19 @@ markers = [
 line-length = 120
 
 [tool.ruff]
-select = ["E", "F", "I", "TID", "W"]
 exclude = [".git", ".ruff_cache", "dist", "docker", "img"]
 fix = false
-ignore-init-module-imports = true
 line-length = 120
 target-version = "py310"
 
-[tool.ruff.flake8-tidy-imports]
+[tool.ruff.lint]
+select = ["E", "F", "I", "TID", "W"]
+ignore-init-module-imports = true
+
+[tool.ruff.lint.flake8-tidy-imports]
 ban-relative-imports = "all"
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 combine-as-imports = true
 force-single-line = false
 order-by-type = false

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,27 @@
+"""Smoke tests that lock in import paths we've previously been bitten by.
+
+These exist to catch silent breakage when third-party libraries reorganise
+their public API. They don't exercise behaviour, just module structure.
+"""
+
+
+def test_client_imports_cleanly():
+    """`discogs_alert.client` imports a chain that has historically broken
+    (`webdriver_manager.core.utils.ChromeType` moved to `core.os_manager`,
+    selenium ChromiumService renamed `log_path` → `log_output`, etc.).
+    """
+
+    from discogs_alert import client  # noqa: F401
+
+
+def test_chrome_type_import_path():
+    """ChromeType lives at `webdriver_manager.core.os_manager` in v4+."""
+
+    from webdriver_manager.core.os_manager import ChromeType  # noqa: F401
+
+
+def test_top_level_modules_import():
+    """Each top-level discogs_alert module imports without side-effect errors."""
+
+    from discogs_alert import alert, client, entities, loop, scrape  # noqa: F401
+    from discogs_alert.util import click, constants, currency, system  # noqa: F401


### PR DESCRIPTION
Stacked on #82.

## Summary
- Bumps all runtime deps to current major versions (selenium ^4.25, webdriver-manager ^4.0, requests ^2.32, beautifulsoup4 ^4.12, fake-useragent ^1.5, schedule ^1.2). Moves \`pre-commit\`/\`ruff\`/\`tox\` from runtime to dev deps where they belong.
- Fixes the imports/calls that broke between versions:
  - \`webdriver_manager.core.utils.ChromeType\` → \`webdriver_manager.core.os_manager.ChromeType\` (webdriver-manager 4.0).
  - selenium \`ChromiumService(log_path=)\` → \`log_output=\` (selenium 4.16+).
  - Chrome \`--headless\` → \`--headless=new\` (Chrome 109+).
  - bs4 \`find(..., text=)\` → \`string=\`.
  - \`os.geteuid\` guarded for Windows.
- Migrates \`[tool.ruff]\` config to the new \`[tool.ruff.lint]\` table layout (top-level \`select\` deprecated in ruff 0.6+).
- Adds \`tests/test_imports.py\` as a smoke test for the import paths that have silently regressed in the past.

## Test plan
- [ ] CI green on 3.10–3.13.
- [ ] \`tests/test_imports.py\` passes.