### PR TITLE
Move alert dedup into a local SQLite store

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ The `-d` flag specifies that you want to "detach" from the newly created docker 
 
 Please note that you _can_ add to or change the contents of your wantlist (either Discogs list or local file) while the service is running; the updated list of releases will come into effect the next time the service runs.
 
-Each time a listing is found for one of the releases in your wantlist, you will be sent a notification via the alerter service of your choice with the title of the release and the URL to the marketplace listing. If you're using Pushbullet, as long as you don't delete a given notification then you will _not_ be sent repeat notifications for the same listing. I hope to add this functionality for the Telegram alerter in due course. You can test that your alerting is working properly by adding a release to your wantlist that you know is currently for sale.
+Each time a listing is found for one of the releases in your wantlist, you will be sent a notification via the alerter service of your choice with the title of the release and the URL to the marketplace listing. Deduplication is handled locally — `discogs_alert` records every successful alert in a small SQLite database (default `~/.discogs_alert/state.db`, configurable via `--state-path`), and won't re-alert on the same listing across loop iterations regardless of which alerter you use. You can test that your alerting is working properly by adding a release to your wantlist that you know is currently for sale.
 
 There are a a number of additional arguments and flags that provide a deeper level of customisation. These optional arguments include the global versions of the conditions mentioned above (i.e. global seller, media, and sleeve conditions), as well as a country whitelist and blacklist. The use of any of these flags will apply to all releases in your wantlist.
 
@@ -204,6 +204,7 @@ Here are the possible arguments:
 * `-pt` `--pushbullet-token`: (str) your pushbullet token (only required if `"--alerter-type=PUSHBULLET"`)
 * `-tt` `--telegram-token`: (str) your telegram API token (only required if `"--alerter-type=TELEGRAM"`)
 * `-tci` `--telegram-chat-id`: (str) your telgram chat ID (only required if `"--alerter-type=TELEGRAM"`)
+* `-sp` `--state-path`: (str) path to the local SQLite database used to deduplicate alerts (default=`~/.discogs_alert/state.db`).
 
 And here are the possible flags:
 * `-V` `--verbose`: (bool) use this flag if you want to run the server in verbose mode, meaning it will log updates to the command line as it runs (default=`false`)

--- a/discogs_alert/__main__.py
+++ b/discogs_alert/__main__.py
@@ -177,6 +177,17 @@ logger = logging.getLogger(__name__)
     help="chat ID for telegram bot notification service.",
 )
 @click.option(
+    "-sp",
+    "--state-path",
+    default=None,
+    type=click.Path(dir_okay=False, file_okay=True),
+    envvar="DA_STATE_PATH",
+    help=(
+        "Path to the local SQLite database used to deduplicate alerts. "
+        "Defaults to `~/.discogs_alert/state.db`."
+    ),
+)
+@click.option(
     "-V", "--verbose", default=False, is_flag=True, help="use flag if you want to see logs as the program runs"
 )
 @click.option(
@@ -206,6 +217,7 @@ def main(
     pushbullet_token,
     telegram_token,
     telegram_chat_id,
+    state_path,
     verbose,
     test,
 ):
@@ -226,21 +238,22 @@ def main(
     else:
         raise ValueError("We should never get here")
 
-    args = [
-        discogs_token,
-        list_id,
-        wantlist_path,
-        user_agent,
-        country,
-        currency,
-        da_entities.SellerFilters(min_seller_rating, min_seller_sales),
-        da_entities.RecordFilters(min_media_condition, min_sleeve_condition),
-        set(dac.COUNTRIES[c] for c in country_whitelist),
-        set(dac.COUNTRIES[c] for c in country_blacklist),
-        alerter_type,
-        alerter_kwargs,
-        verbose,
-    ]
+    loop_kwargs = dict(
+        discogs_token=discogs_token,
+        list_id=list_id,
+        wantlist_path=wantlist_path,
+        user_agent=user_agent,
+        country=country,
+        currency=currency,
+        seller_filters=da_entities.SellerFilters(min_seller_rating, min_seller_sales),
+        record_filters=da_entities.RecordFilters(min_media_condition, min_sleeve_condition),
+        country_whitelist=set(dac.COUNTRIES[c] for c in country_whitelist),
+        country_blacklist=set(dac.COUNTRIES[c] for c in country_blacklist),
+        alerter_type=alerter_type,
+        alerter_kwargs=alerter_kwargs,
+        state_path=state_path,
+        verbose=verbose,
+    )
 
     logger.info(
         r"""
@@ -255,9 +268,9 @@ def main(
 """
     )
 
-    da_loop.loop(*args)
+    da_loop.loop(**loop_kwargs)
     if not test:
-        schedule.every(int(60 / frequency)).minutes.do(lambda: da_loop.loop(*args))
+        schedule.every(int(60 / frequency)).minutes.do(lambda: da_loop.loop(**loop_kwargs))
         while 1:
             schedule.run_pending()
             time.sleep(1)

--- a/discogs_alert/alert/base.py
+++ b/discogs_alert/alert/base.py
@@ -1,16 +1,21 @@
-from typing import Dict, Set
+"""Alerter base class.
 
-AlertDict = Dict[str, Set[str]]
+An `Alerter` is the thinnest possible delivery primitive: given a title and a body,
+push a notification through some external service. Deduplication has been moved to
+the `discogs_alert.state.AlertStore`, so alerters no longer need to query their own
+history.
+"""
+
+from __future__ import annotations
 
 
 class Alerter:
-    def __init__(self):
-        ...
+    """Base class for notification providers.
 
-    def get_all_alerts(self) -> AlertDict:
-        """Returns a list of all alerts previously sent s.t. they can be searched to avoid duplicates."""
-        raise NotImplementedError
+    Subclasses implement `send_alert`. Returning `True` indicates a successful send
+    (the loop will then record the alert in the local store). Returning `False`
+    means we should *not* mark the alert as sent — the loop will retry next iteration.
+    """
 
-    def send_alert(self, message_title: str, message_body: str):
-        """Returns a list of all alerts previously sent s.t. they can be searched to avoid duplicates."""
+    def send_alert(self, message_title: str, message_body: str) -> bool:
         raise NotImplementedError

--- a/discogs_alert/alert/pushbullet.py
+++ b/discogs_alert/alert/pushbullet.py
@@ -1,64 +1,39 @@
+"""Pushbullet alerter.
+
+Uses the v2 Pushes API (https://docs.pushbullet.com/#pushes). Deduplication is no
+longer this alerter's concern — see `discogs_alert.state.AlertStore`.
+"""
+
+from __future__ import annotations
+
 import json
 import logging
-import time
-from collections import defaultdict
 
 import requests
 
-from discogs_alert.alert.base import AlertDict, Alerter
+from discogs_alert.alert.base import Alerter
 
 logger = logging.getLogger(__name__)
+
+PUSHBULLET_API_URL = "https://api.pushbullet.com/v2/pushes"
+HTTP_TIMEOUT_SECONDS = 10
 
 
 class PushbulletAlerter(Alerter):
     def __init__(self, pushbullet_token: str):
         self.pushbullet_token = pushbullet_token
 
-    def get_all_alerts(self) -> AlertDict:
-        headers = {"Authorization": "Bearer " + self.pushbullet_token, "Content-Type": "application/json"}
-        url = "https://api.pushbullet.com/v2/pushes?active=true&limit=500"
-        resp = requests.get(url, headers=headers)
-        rate_limit_remaining = int(resp.headers.get("X-Ratelimit-Remaining"))
-        while rate_limit_remaining < 2:
-            logger.info("About to hit pushbullet's rate limit, waiting 60s")
-            time.sleep(60)
-            resp = requests.get(url, headers=headers)
-            rate_limit_remaining = int(resp.headers.get("X-Ratelimit-Remaining"))
-        resp = resp.json()
-        pushes, cursor = resp.get("pushes"), resp.get("cursor")
-        if len(pushes) == 0:
-            cursor = None
-        while cursor is not None:
-            if rate_limit_remaining < 2:
-                logger.info("About to hit pushbullet's rate limit, waiting 60s")
-                time.sleep(60)
-            resp = requests.get(url + f"&cursor={cursor}", headers=headers)
-            rate_limit_remaining = int(resp.headers.get("X-Ratelimit-Remaining"))
-            resp = resp.json()
-            resp_pushes, resp_cursor = resp.get("pushes"), resp.get("cursor")
-            if len(resp_pushes) == 0:
-                resp_cursor = None
-            pushes += resp_pushes
-            cursor = resp_cursor
-
-        # reorganise the linear list of pushes —> the AlertsDict format
-        pushes_dict = defaultdict(set)
-        for p in pushes:
-            if "title" in p and "body" in p:
-                pushes_dict[p["title"]].add(p["body"])
-
-        return pushes_dict
-
     def send_alert(self, message_title: str, message_body: str) -> bool:
+        headers = {"Authorization": f"Bearer {self.pushbullet_token}", "Content-Type": "application/json"}
+        message = {"type": "note", "title": message_title, "body": message_body}
         try:
-            headers = {"Authorization": "Bearer " + self.pushbullet_token, "Content-Type": "application/json"}
-            message = {"type": "note", "title": message_title, "body": message_body}
-            url = "https://api.pushbullet.com/v2/pushes"
-            resp = requests.post(url, data=json.dumps(message), headers=headers)
-            if resp.status_code != 200:
-                logger.error(f"error {resp.status_code} sending pushbullet notification: {resp.content}")
-                return False
-            return True
+            resp = requests.post(
+                PUSHBULLET_API_URL, data=json.dumps(message), headers=headers, timeout=HTTP_TIMEOUT_SECONDS
+            )
         except requests.exceptions.RequestException:
             logger.error("Exception sending pushbullet push", exc_info=True)
             return False
+        if resp.status_code != 200:
+            logger.error("error %s sending pushbullet notification: %s", resp.status_code, resp.content[:200])
+            return False
+        return True

--- a/discogs_alert/alert/telegram.py
+++ b/discogs_alert/alert/telegram.py
@@ -1,10 +1,17 @@
+"""Telegram alerter (sendMessage via the Bot API)."""
+
+from __future__ import annotations
+
 import logging
 
 import requests
 
-from discogs_alert.alert.base import AlertDict, Alerter
+from discogs_alert.alert.base import Alerter
 
 logger = logging.getLogger(__name__)
+
+TELEGRAM_API_BASE = "https://api.telegram.org"
+HTTP_TIMEOUT_SECONDS = 10
 
 
 class TelegramAlerter(Alerter):
@@ -12,16 +19,20 @@ class TelegramAlerter(Alerter):
         self.bot_token = telegram_token
         self.bot_chat_id = telegram_chat_id
 
-    def get_all_alerts(self) -> AlertDict:
-        return {}
-
-    def send_alert(self, message_title: str, message_body: str):
-        requests.get(
-            "https://api.telegram.org/bot"
-            + self.bot_token
-            + "/sendMessage?chat_id="
-            + self.bot_chat_id
-            + "&parse_mode=Markdown&text="
-            + message_title
-            + f" ({message_body})"
-        )
+    def send_alert(self, message_title: str, message_body: str) -> bool:
+        # The Bot API tolerates a single combined `text` payload; format it lightly.
+        text = f"{message_title} ({message_body})"
+        url = f"{TELEGRAM_API_BASE}/bot{self.bot_token}/sendMessage"
+        try:
+            resp = requests.post(
+                url,
+                json={"chat_id": self.bot_chat_id, "parse_mode": "Markdown", "text": text},
+                timeout=HTTP_TIMEOUT_SECONDS,
+            )
+        except requests.exceptions.RequestException:
+            logger.error("Exception sending telegram message", exc_info=True)
+            return False
+        if resp.status_code != 200:
+            logger.error("error %s sending telegram notification: %s", resp.status_code, resp.text[:200])
+            return False
+        return True

--- a/discogs_alert/loop.py
+++ b/discogs_alert/loop.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List, Optional, Set
 import dacite
 from requests.exceptions import ConnectionError
 
-from discogs_alert import client as da_client, entities as da_entities
+from discogs_alert import client as da_client, entities as da_entities, state as da_state
 from discogs_alert.alert import Alerter, get_alerter
 from discogs_alert.util import constants as dac
 
@@ -37,6 +37,79 @@ def load_wantlist(
     return wantlist
 
 
+def process_release(
+    release: da_entities.Release,
+    client_anon: da_client.AnonClient,
+    currency: str,
+    country: str,
+    seller_filters: da_entities.SellerFilters,
+    record_filters: da_entities.RecordFilters,
+    country_whitelist: Set[str],
+    country_blacklist: Set[str],
+    alerter: Alerter,
+    store: da_state.AlertStore,
+    verbose: bool = False,
+) -> int:
+    """Find listings for a single release that satisfy the user's filters, alert on them
+    if we haven't already, and record successful alerts in the local store. Returns the
+    number of new alerts sent.
+    """
+
+    new_alerts = 0
+    for listing in client_anon.get_marketplace_listings(release.id):
+        try:
+            listing = listing.convert_currency(currency)
+        except Exception:
+            logger.warning("Currency conversion failed; continuing without.", exc_info=True)
+
+        if listing.is_definitely_unavailable(country):
+            if verbose:
+                logger.info(
+                    "Listing found that's unavailable in %s:\n\tRelease: %s\n\tListing: %s",
+                    country,
+                    release.display_title,
+                    listing.url,
+                )
+            continue
+
+        if not da_entities.conditions_satisfied(
+            listing, release, seller_filters, record_filters, country_whitelist, country_blacklist
+        ):
+            if verbose:
+                logger.info(
+                    "Listing found that doesn't satisfy conditions:\n\tRelease: %s\n\tListing: %s",
+                    release.display_title,
+                    listing.url,
+                )
+            continue
+
+        # Compare against the threshold only when the listing is in the user's
+        # currency — the price-conversion call above can silently fail and we
+        # don't want to compare apples to oranges in that case.
+        if listing.price.currency == currency and listing.price_is_above_threshold(release.price_threshold):
+            if verbose:
+                logger.info(
+                    "Listing found that's above the price threshold:\n\tRelease: %s\n\tListing: %s",
+                    release.display_title,
+                    listing.url,
+                )
+            continue
+
+        if store.has_seen(listing.id):
+            if verbose:
+                logger.info("Listing %s for %s already alerted; skipping", listing.id, release.display_title)
+            continue
+
+        message_title = f"Now For Sale: {release.display_title}"
+        message_body = f"Listing available: {listing.url}"
+        price_string = f"{dac.CURRENCIES_REVERSED[listing.price.currency]}{listing.total_price:.2f}"
+        logger.info("%s (%s) — %s", message_title, price_string, message_body)
+        if alerter.send_alert(message_title, message_body):
+            store.mark_seen(listing.id, release.id, message_title, message_body)
+            new_alerts += 1
+    return new_alerts
+
+
 def loop(
     discogs_token: str,
     list_id: Optional[int],
@@ -50,93 +123,63 @@ def loop(
     country_blacklist: Set[str],
     alerter_type: Alerter,
     alerter_kwargs: Dict[str, Any],
+    state_path: Optional[Path] = None,
     verbose: bool = False,
 ):
-    """Event loop, each time this is called we query the discogs marketplace for all items in wantlist."""
+    """Event loop. One iteration: pull the wantlist, query the marketplace for each
+    release, send alerts for newly-seen listings that pass the user's filters.
+
+    Alert dedup is local — backed by `discogs_alert.state.AlertStore`. The alerter
+    itself is now stateless from the loop's point of view.
+    """
 
     start_time = time.time()
     if verbose:
-        logger.info("\nrunning loop")
+        logger.info("running loop")
 
-    client_anon = None
+    client_anon: Optional[da_client.AnonClient] = None
     try:
         client_anon = da_client.AnonClient(user_agent)
         user_token_client = da_client.UserTokenClient(user_agent, discogs_token)
-
         alerter = get_alerter(alerter_type, alerter_kwargs)
-        alerts_dict = alerter.get_all_alerts()  # the list of all previous alerts
 
-        wantlist_items = load_wantlist(list_id, user_token_client, wantlist_path)
-        random.shuffle(wantlist_items)
-        for idx, release in enumerate(wantlist_items):
-            valid_listings: List[da_entities.Listing] = []
-
-            # the discogs API has a 60-request-per-minute limit that only resets after 60s of inactivity
-            if user_token_client.rate_limit_remaining == 1:
-                time.sleep(60)
-
-            for listing in client_anon.get_marketplace_listings(release.id):
-                try:
-                    listing = listing.convert_currency(currency)  # convert —> the base currency
-                except:  # noqa: E722
-                    logger.warning("Currency conversion failed, => continuing without.", exc_info=True)
-
-                # if listing is definitely unavailable, move to the next listing
-                if listing.is_definitely_unavailable(country):
-                    if verbose:
-                        logger.info(
-                            f"Listing found that's unavailable in {country}:\n"
-                            f"\tRelease: {release.display_title}\n"
-                            f"\tListing: {listing.url}"
-                        )
-                    continue
-
-                # if seller, sleeve, and media conditions are not satisfied, move to the next listing
-                if not da_entities.conditions_satisfied(
-                    listing, release, seller_filters, record_filters, country_whitelist, country_blacklist
+        with da_state.AlertStore(state_path) as store:
+            wantlist_items = load_wantlist(list_id, user_token_client, wantlist_path)
+            random.shuffle(wantlist_items)
+            for release in wantlist_items:
+                # The Discogs API has a 60-req/min limit that only resets after 60s of
+                # inactivity. Sleep proactively if we're close to the floor.
+                if (
+                    user_token_client.rate_limit_remaining is not None
+                    and user_token_client.rate_limit_remaining <= 2
                 ):
-                    if verbose:
-                        logger.info(
-                            f"Listing found that doesn't satisfy conditions:\n"
-                            f"\tRelease: {release.display_title}\n"
-                            f"\tListing: {listing.url}"
-                        )
-                    continue
+                    logger.info("approaching Discogs API rate limit; sleeping 60s")
+                    time.sleep(60)
 
-                # if the price is above our threshold, move to the next listing
-                if listing.price.currency == currency:
-                    if listing.price_is_above_threshold(release.price_threshold):
-                        if verbose:
-                            logger.info(
-                                f"Listing found that's above the price threshold:\n"
-                                f"\tRelease: {release.display_title}\n"
-                                f"\tListing: {listing.url}"
-                            )
-                        continue
-
-                valid_listings.append(listing)
-
-            # if we found something, send notification
-            message_title = f"Now For Sale: {release.display_title}"
-            for listing in valid_listings:
-                message_body = f"Listing available: {listing.url}"
-                if message_title not in alerts_dict or message_body not in alerts_dict[message_title]:
-                    price_string = f"{dac.CURRENCIES_REVERSED[listing.price.currency]}{listing.total_price:.2f}"
-                    logger.info(f"{message_title} ({price_string}) — {message_body}")
-                    alerter.send_alert(message_title, message_body)
+                process_release(
+                    release,
+                    client_anon,
+                    currency,
+                    country,
+                    seller_filters,
+                    record_filters,
+                    country_whitelist,
+                    country_blacklist,
+                    alerter,
+                    store,
+                    verbose=verbose,
+                )
 
     except ConnectionError:
         logger.info("ConnectionError: looping will continue as usual", exc_info=True)
+    except Exception:
+        logger.exception("Unexpected exception in loop; continuing")
+    finally:
+        if client_anon is not None:
+            try:
+                client_anon.driver.close()
+                client_anon.driver.quit()
+            except Exception:
+                logger.warning("error tearing down anonymous client driver", exc_info=True)
 
-    except AttributeError:
-        logger.info("AttributeError: will continue looping as usual", exc_info=True)
-
-    except:  # noqa: E722
-        logger.info("Exception: this might be a real exception, but we're continuing anyway", exc_info=True)
-
-    logger.info(f"\t took {time.time() - start_time}")
-
-    # clean up Chrome clients
-    if client_anon is not None:
-        client_anon.driver.close()
-        client_anon.driver.quit()
+    logger.info("\t took %.2fs", time.time() - start_time)

--- a/discogs_alert/state.py
+++ b/discogs_alert/state.py
@@ -1,0 +1,107 @@
+"""Local persistent state for `discogs_alert`.
+
+Historically, alert deduplication was the alerter's responsibility — the Pushbullet
+alerter, for example, paginated the user's entire push history on every loop iteration
+(every minute by default) just to check whether a given listing had already been
+alerted on. That was the project's single biggest source of upstream rate-limit pain,
+and it didn't even work for Telegram (whose alerter just returned an empty dict).
+
+Moving dedup into a local SQLite database keyed on Discogs `listing_id` (which is
+globally unique across the marketplace) eliminates the recurring history scan,
+fixes Telegram dedup as a side-effect, and decouples the alerters from the question
+of "have I sent this before?".
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_STATE_DIR = Path.home() / ".discogs_alert"
+DEFAULT_STATE_PATH = DEFAULT_STATE_DIR / "state.db"
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS sent_alerts (
+    listing_id INTEGER PRIMARY KEY,
+    release_id INTEGER NOT NULL,
+    title      TEXT    NOT NULL,
+    body       TEXT    NOT NULL,
+    sent_at    TEXT    NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_sent_alerts_release_id ON sent_alerts(release_id);
+CREATE INDEX IF NOT EXISTS idx_sent_alerts_sent_at   ON sent_alerts(sent_at);
+"""
+
+
+class AlertStore:
+    """SQLite-backed log of alerts we've already delivered.
+
+    The store is intentionally small and synchronous — there's no concurrent writer
+    in this project (the loop runs serially), and a single-table SQLite database is
+    enough that we don't need to involve a heavier dependency.
+
+    Records are keyed by `listing_id` (globally unique on Discogs); all other fields
+    are stored for forensics.
+    """
+
+    def __init__(self, path: Optional[Path] = None) -> None:
+        self.path = Path(path) if path is not None else DEFAULT_STATE_PATH
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(self.path)
+        self._conn.executescript(_SCHEMA)
+        self._conn.commit()
+
+    def close(self) -> None:
+        self._conn.close()
+
+    def __enter__(self) -> "AlertStore":
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.close()
+
+    def has_seen(self, listing_id: int) -> bool:
+        """Return True if we've already delivered an alert for this listing."""
+
+        cur = self._conn.execute("SELECT 1 FROM sent_alerts WHERE listing_id = ? LIMIT 1", (listing_id,))
+        return cur.fetchone() is not None
+
+    def mark_seen(self, listing_id: int, release_id: int, title: str, body: str) -> None:
+        """Record that we've delivered an alert for `listing_id`. Idempotent: re-marking
+        an existing listing is a no-op (kept as INSERT OR IGNORE so a partial duplicate
+        delivery doesn't blow up).
+        """
+
+        with self._conn:
+            self._conn.execute(
+                "INSERT OR IGNORE INTO sent_alerts (listing_id, release_id, title, body) VALUES (?, ?, ?, ?)",
+                (int(listing_id), int(release_id), title, body),
+            )
+
+    def count(self) -> int:
+        """Return the number of recorded alerts (mostly useful for tests/debug logs)."""
+
+        cur = self._conn.execute("SELECT COUNT(*) FROM sent_alerts")
+        return int(cur.fetchone()[0])
+
+    def prune_older_than(self, days: int) -> int:
+        """Delete alert records older than `days` days. Returns the number of rows
+        deleted.
+
+        The store grows ~slowly (one row per delivered alert) but there's no good
+        reason to keep records forever. Listings that disappeared from Discogs months
+        ago will never reappear, so old rows are pure baggage.
+        """
+
+        if days < 0:
+            raise ValueError("`days` must be non-negative")
+        with self._conn:
+            cur = self._conn.execute(
+                "DELETE FROM sent_alerts WHERE sent_at < datetime('now', ?)",
+                (f"-{int(days)} days",),
+            )
+            return int(cur.rowcount)

--- a/tests/notify/test_telegram.py
+++ b/tests/notify/test_telegram.py
@@ -1,51 +1,47 @@
-import json
 from unittest.mock import MagicMock
 
 import pytest
 import requests
 
-from discogs_alert.alert import pushbullet as da_pushbullet
+from discogs_alert.alert import telegram as da_telegram
 
 
 @pytest.fixture
-def alerter() -> da_pushbullet.PushbulletAlerter:
-    return da_pushbullet.PushbulletAlerter(pushbullet_token="TEST_TOKEN")
+def alerter() -> da_telegram.TelegramAlerter:
+    return da_telegram.TelegramAlerter(telegram_token="TEST_TOKEN", telegram_chat_id="42")
 
 
-def _fake_post(status_code: int = 200, content: bytes = b"{}", raise_exc=None):
+def _fake_post(status_code: int = 200, raise_exc=None):
     captured: dict = {}
 
-    def _post(url, data=None, headers=None, timeout=None):
+    def _post(url, json=None, timeout=None):
         captured["url"] = url
-        captured["data"] = data
-        captured["headers"] = headers
+        captured["json"] = json
         captured["timeout"] = timeout
         if raise_exc is not None:
             raise raise_exc
         resp = MagicMock()
         resp.status_code = status_code
-        resp.content = content
+        resp.text = "{}"
         return resp
 
     return _post, captured
 
 
 def test_send_alert_posts_correct_payload(monkeypatch: pytest.MonkeyPatch, alerter):
-    post, captured = _fake_post(200)
+    post, captured = _fake_post()
     monkeypatch.setattr(requests, "post", post)
 
     assert alerter.send_alert("title", "body") is True
-
-    assert captured["url"] == da_pushbullet.PUSHBULLET_API_URL
-    assert captured["headers"]["Authorization"] == "Bearer TEST_TOKEN"
-    assert captured["headers"]["Content-Type"] == "application/json"
-    assert captured["timeout"] == da_pushbullet.HTTP_TIMEOUT_SECONDS
-    body = json.loads(captured["data"])
-    assert body == {"type": "note", "title": "title", "body": "body"}
+    assert captured["url"] == f"{da_telegram.TELEGRAM_API_BASE}/botTEST_TOKEN/sendMessage"
+    assert captured["json"]["chat_id"] == "42"
+    assert captured["json"]["parse_mode"] == "Markdown"
+    assert captured["json"]["text"] == "title (body)"
+    assert captured["timeout"] == da_telegram.HTTP_TIMEOUT_SECONDS
 
 
 def test_send_alert_returns_false_on_non_200(monkeypatch: pytest.MonkeyPatch, alerter):
-    post, _ = _fake_post(429, b'{"error":"rate"}')
+    post, _ = _fake_post(status_code=400)
     monkeypatch.setattr(requests, "post", post)
     assert alerter.send_alert("title", "body") is False
 

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -1,0 +1,308 @@
+"""Tests for the loop module: `process_release` (per-release alerting flow),
+`load_wantlist` (wantlist parsing), and `loop` (orchestration with mocks).
+
+We don't exercise the full `loop()` end-to-end because it spins up Selenium and
+a real Discogs client. Instead we test `process_release` against a fake
+`AnonClient` and a real local `AlertStore` (which is what actually owns the
+dedup contract), and we mock the clients when exercising `loop` itself.
+"""
+
+import json
+from pathlib import Path
+from typing import List
+from unittest.mock import MagicMock
+
+import pytest
+
+from discogs_alert import client as da_client, entities as da_entities, loop as da_loop, state as da_state
+from discogs_alert.alert import AlerterType
+
+
+class FakeClient:
+    """Stand-in for `AnonClient` returning a canned listings list."""
+
+    def __init__(self, listings: List[da_entities.Listing]):
+        self._listings = listings
+
+    def get_marketplace_listings(self, _release_id: int):
+        return list(self._listings)
+
+
+class RecordingAlerter:
+    def __init__(self, send_returns: bool = True):
+        self.calls: List[tuple] = []
+        self.send_returns = send_returns
+
+    def send_alert(self, title: str, body: str) -> bool:
+        self.calls.append((title, body))
+        return self.send_returns
+
+
+def _listing(listing_id: int, value_eur: float) -> da_entities.Listing:
+    return da_entities.Listing(
+        id=listing_id,
+        availability=None,
+        media_condition=da_entities.CONDITION.NEAR_MINT,
+        sleeve_condition=da_entities.CONDITION.NEAR_MINT,
+        comment="",
+        seller_num_ratings=100,
+        seller_avg_rating=100.0,
+        seller_ships_from="Germany",
+        price=da_entities.ListingPrice(currency="EUR", value=value_eur, shipping=None),
+    )
+
+
+def _release() -> da_entities.Release:
+    return da_entities.Release(id=42, display_title="Test Release", price_threshold=100)
+
+
+def _filters():
+    return (
+        da_entities.SellerFilters(min_seller_rating=99, min_seller_sales=None),
+        da_entities.RecordFilters(
+            min_media_condition=da_entities.CONDITION.VERY_GOOD,
+            min_sleeve_condition=da_entities.CONDITION.NOT_GRADED,
+        ),
+        set(),  # whitelist
+        set(),  # blacklist
+    )
+
+
+# -- process_release --------------------------------------------------------
+
+
+def test_alerts_on_new_listing(tmp_path: Path):
+    seller, record, wl, bl = _filters()
+    listing = _listing(listing_id=1, value_eur=50)
+    client = FakeClient([listing])
+    alerter = RecordingAlerter()
+
+    with da_state.AlertStore(tmp_path / "state.db") as store:
+        sent = da_loop.process_release(
+            _release(), client, "EUR", "Germany", seller, record, wl, bl, alerter, store
+        )
+        assert sent == 1
+        assert len(alerter.calls) == 1
+        assert store.has_seen(1)
+
+
+def test_does_not_alert_twice_for_same_listing(tmp_path: Path):
+    seller, record, wl, bl = _filters()
+    listing = _listing(listing_id=1, value_eur=50)
+    alerter = RecordingAlerter()
+
+    with da_state.AlertStore(tmp_path / "state.db") as store:
+        # First pass alerts
+        da_loop.process_release(
+            _release(), FakeClient([listing]), "EUR", "Germany", seller, record, wl, bl, alerter, store
+        )
+        # Second pass with the same listing should be a no-op
+        sent = da_loop.process_release(
+            _release(), FakeClient([listing]), "EUR", "Germany", seller, record, wl, bl, alerter, store
+        )
+        assert sent == 0
+        assert len(alerter.calls) == 1
+
+
+def test_skips_listings_above_price_threshold(tmp_path: Path):
+    seller, record, wl, bl = _filters()
+    listing = _listing(listing_id=1, value_eur=200)  # > threshold of 100
+    alerter = RecordingAlerter()
+
+    with da_state.AlertStore(tmp_path / "state.db") as store:
+        sent = da_loop.process_release(
+            _release(), FakeClient([listing]), "EUR", "Germany", seller, record, wl, bl, alerter, store
+        )
+        assert sent == 0
+        assert alerter.calls == []
+        assert not store.has_seen(1)
+
+
+def test_skips_listings_unavailable_in_country(tmp_path: Path):
+    seller, record, wl, bl = _filters()
+    listing = _listing(listing_id=1, value_eur=50)
+    listing.availability = "Unavailable in Germany"
+    alerter = RecordingAlerter()
+
+    with da_state.AlertStore(tmp_path / "state.db") as store:
+        sent = da_loop.process_release(
+            _release(), FakeClient([listing]), "EUR", "Germany", seller, record, wl, bl, alerter, store
+        )
+        assert sent == 0
+        assert alerter.calls == []
+
+
+def test_does_not_mark_seen_when_alerter_fails(tmp_path: Path):
+    seller, record, wl, bl = _filters()
+    listing = _listing(listing_id=1, value_eur=50)
+    alerter = RecordingAlerter(send_returns=False)
+
+    with da_state.AlertStore(tmp_path / "state.db") as store:
+        sent = da_loop.process_release(
+            _release(), FakeClient([listing]), "EUR", "Germany", seller, record, wl, bl, alerter, store
+        )
+        assert sent == 0
+        assert len(alerter.calls) == 1  # we tried
+        assert not store.has_seen(1)  # but didn't record success — will retry next iteration
+
+
+def test_alerts_independently_for_distinct_listings(tmp_path: Path):
+    seller, record, wl, bl = _filters()
+    listings = [_listing(listing_id=1, value_eur=50), _listing(listing_id=2, value_eur=60)]
+    alerter = RecordingAlerter()
+
+    with da_state.AlertStore(tmp_path / "state.db") as store:
+        sent = da_loop.process_release(
+            _release(), FakeClient(listings), "EUR", "Germany", seller, record, wl, bl, alerter, store
+        )
+        assert sent == 2
+        assert {c[0] for c in alerter.calls} == {"Now For Sale: Test Release"}
+        assert store.has_seen(1) and store.has_seen(2)
+
+
+# -- load_wantlist ----------------------------------------------------------
+
+
+def test_load_wantlist_from_local_json(tmp_path: Path):
+    path = tmp_path / "wl.json"
+    path.write_text(
+        json.dumps(
+            [
+                {"id": 1, "display_title": "A", "min_media_condition": "VERY_GOOD"},
+                {"id": 2, "display_title": "B", "min_sleeve_condition": "NEAR_MINT", "price_threshold": 50},
+                {"id": 3, "display_title": "C"},
+            ]
+        )
+    )
+    wl = da_loop.load_wantlist(wantlist_path=str(path))
+    assert [r.id for r in wl] == [1, 2, 3]
+    assert wl[0].min_media_condition == da_entities.CONDITION.VERY_GOOD
+    assert wl[1].min_sleeve_condition == da_entities.CONDITION.NEAR_MINT
+    assert wl[1].price_threshold == 50
+
+
+def test_load_wantlist_from_user_token_client():
+    """When a `list_id` is provided, the wantlist comes from the Discogs API client."""
+
+    fake_client = MagicMock()
+    fake_client.get_list.return_value = MagicMock(items=[da_entities.Release(id=1, display_title="X")])
+    wl = da_loop.load_wantlist(list_id=42, user_token_client=fake_client)
+    fake_client.get_list.assert_called_once_with(42)
+    assert wl[0].id == 1
+
+
+def test_load_wantlist_requires_a_source():
+    with pytest.raises(AssertionError):
+        da_loop.load_wantlist(list_id=None, user_token_client=None, wantlist_path=None)
+
+
+# -- loop (orchestration) ---------------------------------------------------
+
+
+def test_loop_runs_and_calls_process_release(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """End-to-end-ish: stub out the Discogs clients and AlerterType, verify `loop`
+    walks the wantlist and tears down cleanly.
+    """
+
+    wl = tmp_path / "wl.json"
+    wl.write_text(json.dumps([{"id": 1, "display_title": "A"}, {"id": 2, "display_title": "B"}]))
+
+    fake_anon = MagicMock()
+    fake_anon.driver = MagicMock()
+    fake_user_client = MagicMock()
+    fake_user_client.rate_limit_remaining = 50
+
+    process_calls = []
+
+    def fake_process_release(release, client, *_args, **_kwargs):
+        process_calls.append(release.id)
+        return 0
+
+    monkeypatch.setattr(da_client, "AnonClient", lambda *_a, **_kw: fake_anon)
+    monkeypatch.setattr(da_client, "UserTokenClient", lambda *_a, **_kw: fake_user_client)
+    monkeypatch.setattr(da_loop, "process_release", fake_process_release)
+
+    da_loop.loop(
+        discogs_token="X",
+        list_id=None,
+        wantlist_path=str(wl),
+        user_agent="UA",
+        country="Germany",
+        currency="EUR",
+        seller_filters=da_entities.SellerFilters(),
+        record_filters=da_entities.RecordFilters(),
+        country_whitelist=set(),
+        country_blacklist=set(),
+        alerter_type=AlerterType.PUSHBULLET,
+        alerter_kwargs={"pushbullet_token": "T"},
+        state_path=tmp_path / "state.db",
+    )
+
+    assert sorted(process_calls) == [1, 2]
+    fake_anon.driver.close.assert_called_once()
+    fake_anon.driver.quit.assert_called_once()
+
+
+def test_loop_tears_down_driver_on_exception(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    fake_anon = MagicMock()
+    fake_anon.driver = MagicMock()
+    fake_user_client = MagicMock()
+    fake_user_client.rate_limit_remaining = 50
+
+    monkeypatch.setattr(da_client, "AnonClient", lambda *_a, **_kw: fake_anon)
+    monkeypatch.setattr(da_client, "UserTokenClient", lambda *_a, **_kw: fake_user_client)
+    monkeypatch.setattr(da_loop, "load_wantlist", lambda *_a, **_kw: (_ for _ in ()).throw(RuntimeError("boom")))
+
+    # Should not raise — `loop` swallows exceptions to keep the schedule alive.
+    da_loop.loop(
+        discogs_token="X",
+        list_id=42,
+        wantlist_path=None,
+        user_agent="UA",
+        country="Germany",
+        currency="EUR",
+        seller_filters=da_entities.SellerFilters(),
+        record_filters=da_entities.RecordFilters(),
+        country_whitelist=set(),
+        country_blacklist=set(),
+        alerter_type=AlerterType.PUSHBULLET,
+        alerter_kwargs={"pushbullet_token": "T"},
+        state_path=tmp_path / "state.db",
+    )
+
+    fake_anon.driver.close.assert_called_once()
+    fake_anon.driver.quit.assert_called_once()
+
+
+def test_loop_sleeps_when_rate_limit_low(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    wl = tmp_path / "wl.json"
+    wl.write_text(json.dumps([{"id": 1, "display_title": "A"}]))
+
+    fake_anon = MagicMock()
+    fake_anon.driver = MagicMock()
+    fake_user_client = MagicMock()
+    fake_user_client.rate_limit_remaining = 1  # below the threshold of 2
+
+    monkeypatch.setattr(da_client, "AnonClient", lambda *_a, **_kw: fake_anon)
+    monkeypatch.setattr(da_client, "UserTokenClient", lambda *_a, **_kw: fake_user_client)
+    monkeypatch.setattr(da_loop, "process_release", lambda *a, **k: 0)
+    sleep_calls = []
+    monkeypatch.setattr(da_loop.time, "sleep", lambda s: sleep_calls.append(s))
+
+    da_loop.loop(
+        discogs_token="X",
+        list_id=None,
+        wantlist_path=str(wl),
+        user_agent="UA",
+        country="Germany",
+        currency="EUR",
+        seller_filters=da_entities.SellerFilters(),
+        record_filters=da_entities.RecordFilters(),
+        country_whitelist=set(),
+        country_blacklist=set(),
+        alerter_type=AlerterType.PUSHBULLET,
+        alerter_kwargs={"pushbullet_token": "T"},
+        state_path=tmp_path / "state.db",
+    )
+
+    assert 60 in sleep_calls

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,0 +1,120 @@
+import sqlite3
+import time
+from pathlib import Path
+
+import pytest
+
+from discogs_alert import state as da_state
+
+
+@pytest.fixture
+def tmp_store(tmp_path: Path) -> da_state.AlertStore:
+    store = da_state.AlertStore(tmp_path / "state.db")
+    yield store
+    store.close()
+
+
+def test_creates_database_file(tmp_path: Path):
+    db_path = tmp_path / "nested" / "state.db"
+    assert not db_path.exists()
+    with da_state.AlertStore(db_path):
+        assert db_path.exists()
+
+
+def test_has_seen_starts_false(tmp_store: da_state.AlertStore):
+    assert tmp_store.has_seen(123) is False
+
+
+def test_mark_then_has_seen(tmp_store: da_state.AlertStore):
+    tmp_store.mark_seen(listing_id=123, release_id=456, title="t", body="b")
+    assert tmp_store.has_seen(123) is True
+    assert tmp_store.has_seen(124) is False
+
+
+def test_mark_seen_is_idempotent(tmp_store: da_state.AlertStore):
+    tmp_store.mark_seen(123, 456, "t", "b")
+    tmp_store.mark_seen(123, 456, "t", "b")  # second call must not raise
+    assert tmp_store.count() == 1
+
+
+def test_count(tmp_store: da_state.AlertStore):
+    assert tmp_store.count() == 0
+    tmp_store.mark_seen(1, 1, "t", "b")
+    tmp_store.mark_seen(2, 1, "t", "b")
+    tmp_store.mark_seen(3, 2, "t", "b")
+    assert tmp_store.count() == 3
+
+
+def test_persists_across_reopen(tmp_path: Path):
+    db_path = tmp_path / "state.db"
+    with da_state.AlertStore(db_path) as store:
+        store.mark_seen(7, 1, "t", "b")
+    with da_state.AlertStore(db_path) as store:
+        assert store.has_seen(7)
+
+
+def test_prune_older_than_keeps_recent(tmp_store: da_state.AlertStore):
+    tmp_store.mark_seen(1, 1, "t", "b")
+    deleted = tmp_store.prune_older_than(days=1)
+    assert deleted == 0
+    assert tmp_store.has_seen(1)
+
+
+def test_prune_older_than_drops_old(tmp_path: Path):
+    db_path = tmp_path / "state.db"
+    with da_state.AlertStore(db_path) as store:
+        # Insert with a hand-rolled `sent_at` 30 days ago, bypassing the default.
+        store._conn.execute(  # noqa: SLF001 — internal access is fine within tests
+            "INSERT INTO sent_alerts (listing_id, release_id, title, body, sent_at) "
+            "VALUES (?, ?, ?, ?, datetime('now', '-30 days'))",
+            (1, 1, "t", "b"),
+        )
+        store._conn.commit()
+
+        deleted = store.prune_older_than(days=7)
+        assert deleted == 1
+        assert not store.has_seen(1)
+
+
+def test_prune_rejects_negative_days(tmp_store: da_state.AlertStore):
+    with pytest.raises(ValueError):
+        tmp_store.prune_older_than(days=-1)
+
+
+def test_default_path_resolves_under_home(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """Construction with no path argument should resolve under `~/.discogs_alert`."""
+
+    monkeypatch.setattr(da_state, "DEFAULT_STATE_DIR", tmp_path / "fakehome" / ".discogs_alert")
+    monkeypatch.setattr(
+        da_state, "DEFAULT_STATE_PATH", tmp_path / "fakehome" / ".discogs_alert" / "state.db"
+    )
+    with da_state.AlertStore() as store:
+        assert store.path == tmp_path / "fakehome" / ".discogs_alert" / "state.db"
+        assert store.path.exists()
+
+
+def test_close_actually_closes_connection(tmp_path: Path):
+    store = da_state.AlertStore(tmp_path / "state.db")
+    store.close()
+    with pytest.raises(sqlite3.ProgrammingError):
+        store.has_seen(1)
+
+
+def test_concurrent_inserts_within_one_window_dedup(tmp_store: da_state.AlertStore):
+    """Two near-simultaneous mark_seen calls for the same listing should not create
+    two rows. (Defends against a brief race in retry paths.)
+    """
+
+    tmp_store.mark_seen(42, 1, "t", "b1")
+    tmp_store.mark_seen(42, 1, "t", "b2")
+    assert tmp_store.count() == 1
+
+
+def test_sent_at_is_iso_like(tmp_store: da_state.AlertStore):
+    """Sanity-check: the default `sent_at` should be parseable as a YYYY-MM-DD HH:MM:SS string."""
+
+    tmp_store.mark_seen(99, 1, "t", "b")
+    cur = tmp_store._conn.execute("SELECT sent_at FROM sent_alerts WHERE listing_id = ?", (99,))
+    sent_at = cur.fetchone()[0]
+    assert isinstance(sent_at, str)
+    time.strptime(sent_at, "%Y-%m-%d %H:%M:%S")


### PR DESCRIPTION
Re-creating #85 (auto-closed when its base branch \`chore/frankfurter-currency-provider\` was deleted by #84's squash-merge before #85 could be retargeted).

## Summary
Dedup was each alerter's responsibility, which was both expensive (Pushbullet re-paginated the whole push history every loop) and broken (Telegram had no dedup). This moves dedup into a tiny local SQLite store keyed on Discogs \`listing_id\`.

- New \`discogs_alert/state.py\` (\`AlertStore\`): \`has_seen\` / \`mark_seen\` / \`count\` / \`prune_older_than\`. Default \`~/.discogs_alert/state.db\`, configurable via \`-sp\`/\`--state-path\`/\`DA_STATE_PATH\`.
- \`Alerter.send_alert\` now returns \`bool\`; \`get_all_alerts\` and \`AlertDict\` are removed.
- Pushbullet/Telegram alerters become stateless with proper request timeouts. Telegram switched from URL-encoded GET to JSON POST so unicode/special chars don't break.
- \`loop.py\`: factor per-release work into \`process_release\`, wire \`AlertStore\`, use try/finally for chrome teardown, tighten \`rate_limit_remaining <= 2\` and threshold-comparison only when currency matches.
- \`__main__.py\`: add \`-sp/--state-path\`, pass loop args by kwarg.
- README: document \`--state-path\`, replace Pushbullet-specific dedup prose.

## Tests (offline, no Discogs traffic)
\`tests/test_state.py\` (CRUD, persistence, prune, idempotency, default-path resolution); \`tests/notify/test_pushbullet.py\` and \`tests/notify/test_telegram.py\` (payload, timeouts, non-200 / network-error returns False); \`tests/test_loop.py\` (\`process_release\` doesn't double-alert, respects threshold/availability/conditions, doesn't mark-seen when alerter returns False; \`load_wantlist\` from both sources).

## Upgrade note
First post-upgrade loop will alert on every currently-matching listing (DB starts empty). Subsequent iterations dedup as intended.