### PR TITLE
Enforce 80% test coverage in tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,4 +10,4 @@ deps =
     pytest-sugar
     pytest-cov
 commands =
-    pytest --cov=discogs_alert --cov-report=term-missing {posargs:tests}
+    pytest --cov=discogs_alert --cov-report=term-missing --cov-fail-under=80 {posargs:tests}


### PR DESCRIPTION
Re-enables \`--cov-fail-under=80\` in \`tox.ini\` now that the rebased stack has merged and main sits at 83.1%. Will be ratcheted up once \`__main__.py\` gets CLI tests in a follow-up.