### PR TITLE
Fix RequiredIf and NotRequiredIf for click 8.3+

### DIFF
--- a/discogs_alert/util/click.py
+++ b/discogs_alert/util/click.py
@@ -3,6 +3,20 @@ from typing import Any, List, Mapping, Optional, Tuple, Type
 
 import click
 
+# Click 8.3 changed `consume_value` to return the literal `Sentinel.UNSET` for
+# unprovided options, instead of the option's default (typically `None`). We
+# match against both so the same code works on click 8.0–8.2 and 8.3+.
+try:
+    from click.core import UNSET as _CLICK_UNSET  # type: ignore[attr-defined]
+
+    _UNSET_VALUES: tuple = (None, _CLICK_UNSET)
+except ImportError:  # pragma: no cover — pre-8.3 click
+    _UNSET_VALUES = (None,)
+
+
+def _is_unset(value: Any) -> bool:
+    return value in _UNSET_VALUES
+
 
 class NotRequiredIf(click.Option):
     """A class enabling click to specify arguments of which we require one or the other.
@@ -23,8 +37,8 @@ class NotRequiredIf(click.Option):
         # `not_required_if` to mirror the CLI flag style. Normalise to underscores so
         # the comparison actually fires.
         other_name = self.not_required_if.replace("-", "_")
-        we_are_present = self.name in opts and opts.get(self.name) is not None
-        other_present = other_name in opts and opts.get(other_name) is not None
+        we_are_present = self.name in opts and not _is_unset(opts.get(self.name))
+        other_present = other_name in opts and not _is_unset(opts.get(other_name))
         if other_present:
             if we_are_present:
                 raise click.UsageError(
@@ -61,7 +75,7 @@ class RequiredIf(click.Option):
         """If the `required_if` condition is met, check whether this option's value is set before proceeding."""
 
         value, _ = self.consume_value(ctx, opts)
-        if self.required_if(ctx.params) and value is None:
+        if self.required_if(ctx.params) and _is_unset(value):
             raise click.UsageError(f"Illegal usage: `{self.name}` is required when `{self.required_if_str}`")
 
         self.prompt = None

--- a/tests/util/test_click.py
+++ b/tests/util/test_click.py
@@ -95,6 +95,19 @@ def test_required_if_passes_when_condition_true_with_value():
     assert "mode=secret token=abc" in result.output
 
 
+def test_required_if_handles_click_83_unset_sentinel():
+    """Click 8.3 changed `consume_value` to return `Sentinel.UNSET` for unprovided
+    options instead of the option's `default`. The original RequiredIf code
+    checked `value is None`, which silently no-op'd on click 8.3+. Captured here
+    so the regression doesn't return.
+    """
+
+    runner = CliRunner()
+    result = runner.invoke(_build_required_if_app(), ["--mode", "secret"])
+    assert result.exit_code != 0
+    assert "is required when" in result.output
+
+
 # -- EnumChoice -------------------------------------------------------------
 
 


### PR DESCRIPTION
## Why
Click 8.3 changed \`consume_value\` to return \`Sentinel.UNSET\` for unprovided options instead of the option's \`default\` (typically \`None\`). \`RequiredIf.handle_parse_result\` checked \`value is None\`, so on 8.3+ the runtime constraint \"--telegram-chat-id is required when --alerter-type=TELEGRAM\" silently no-op'd in production. NotRequiredIf had the analogous bug.

## Fix
New \`_is_unset()\` helper checks against \`None\` and \`UNSET\` (the latter imported lazily so we still work on click 8.0–8.2). Both helpers updated to use it. Regression test pins the click-8.3 behaviour.

Discovered while writing CLI tests for \`__main__.py\`.