### PR TITLE
Defensive scraper: tolerate malformed rows, parse ISO-coded shipping

### DIFF
--- a/discogs_alert/scrape.py
+++ b/discogs_alert/scrape.py
@@ -1,8 +1,9 @@
 import logging
 import re
+from typing import Optional
 
 import dacite
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup, Tag
 
 from discogs_alert import entities as da_entities
 from discogs_alert.util import constants as dac
@@ -37,7 +38,8 @@ def _parse_price_string(price_string: str) -> tuple[str, float]:
         ``(iso_code, numeric_value)``.
 
     Raises:
-        PriceParsingException: if neither a known symbol nor an ISO code is found.
+        PriceParsingException: if neither a known symbol nor an ISO code is found,
+        or if the numeric portion can't be parsed as a float.
     """
 
     price_currency, price_value = None, None
@@ -49,11 +51,59 @@ def _parse_price_string(price_string: str) -> tuple[str, float]:
             if currency in price_string:
                 price_currency = currency
                 price_value = price_string.replace(currency, "")
+                break
 
     if price_currency is None:
         raise PriceParsingException(f"Couldn't parse {price_string}")
 
-    return dac.CURRENCIES[price_currency], float(price_value)
+    try:
+        numeric_value = float(price_value)
+    except (TypeError, ValueError) as exc:
+        raise PriceParsingException(f"Couldn't parse numeric value from {price_string!r}") from exc
+
+    return dac.CURRENCIES[price_currency], numeric_value
+
+
+def _first_text(elt: Optional[Tag]) -> str:
+    """Return the first stripped text child of `elt`, or ``""`` if there isn't one.
+
+    Defensive replacement for ``elt.contents[0].strip()`` which IndexErrors on
+    empty tags (e.g. ``<p></p>``).
+    """
+
+    if elt is None:
+        return ""
+    text = elt.get_text(strip=True) if isinstance(elt, Tag) else str(elt).strip()
+    return text
+
+
+def _parse_shipping(shipping_text: str) -> Optional[dict]:
+    """Try hard to extract a shipping price + currency from the (often messy)
+    Discogs shipping span text.
+
+    Returns ``{"currency": <iso>, "value": <float>}`` or ``None`` if the text
+    has no parseable price (e.g. ``"+free shipping"``, ``"+about shipping"``).
+
+    Handles symbol-prefixed amounts and ISO-code-prefixed amounts.
+    """
+
+    cleaned = shipping_text.strip().replace("+", "").replace(",", "").strip()
+    if not cleaned:
+        return None
+
+    # Drop common noise words so the remainder is easier to parse.
+    for word in ("shipping", "about", "free"):
+        cleaned = cleaned.replace(word, "")
+    cleaned = cleaned.strip()
+
+    if not cleaned:
+        return None
+
+    try:
+        currency, value = _parse_price_string(cleaned)
+        return {"currency": currency, "value": value}
+    except PriceParsingException:
+        return None
 
 
 def scrape_listings_from_marketplace(response_content: str, release_id: int) -> da_entities.Listings:
@@ -64,96 +114,140 @@ def scrape_listings_from_marketplace(response_content: str, release_id: int) -> 
         response_content: content of response from release marketplace GET request
         release_id: the ID of the release, used only for informative logging
 
-    Returns: List of `Listing` objects containing information about each listing for sale.
+    Returns:
+        List of `Listing` objects containing information about each listing for sale.
+        Listings the parser can't fully understand are skipped (and logged) rather
+        than crashing the whole batch.
     """
 
-    listings = []
+    listings: da_entities.Listings = []
 
     soup = BeautifulSoup(response_content, "html.parser")
-
     listings_table = soup.find("table", class_="mpitems")
+    if listings_table is None:
+        logger.info("No mpitems table found for release %s; returning empty list", release_id)
+        return listings
 
-    # each row is a single listing
-    rows = listings_table.find("tbody").find_all("tr")
-    for row in rows:
-        listing = {}
+    tbody = listings_table.find("tbody")
+    if tbody is None:
+        return listings
 
-        item_desc_cell = row.find("td", class_="item_description")
-        seller_info_cell = row.find("td", class_="seller_info")
-        item_price_cell = row.find("td", class_="item_price")
-
-        # get the listing ID
-        listing_url = item_desc_cell.find("a")["href"]
-        listing["id"] = int(listing_url.split("/")[-1].split("?")[0])
-
-        paragraphs = item_desc_cell.find_all("p")
-        num_paragraphs = len(paragraphs)
-
-        # extract listing availability. If there are 4 paragraphs, the first is a
-        # hidden para containing the string "Unavailable in <country>"
-        listing["availability"] = None
-        if num_paragraphs == 4:
-            listing["availability"] = paragraphs[0].contents[0].strip()
-
-        item_condition_para = item_desc_cell.find("p", class_="item_condition")
-
-        # extract conditions of media (always listed) and sleeve (optional)
-        conditions = (da_entities.CONDITION_PARSER.get(s) for s in item_condition_para.stripped_strings)
-        conditions = [c for c in conditions if c is not None]
-        # in case of missing sleeve condition
-        conditions.append(da_entities.CONDITION.NOT_GRADED)
-        listing["media_condition"] = conditions[0]
-        listing["sleeve_condition"] = conditions[1]
-
-        # the seller's comment is the last paragraph (doesn't have a nice class name)
-        seller_comment = paragraphs[-1].contents[0].strip()
-        listing["comment"] = seller_comment
-
-        # extract seller info (num ratings, average rating, & country ships from)
-        is_new_seller = str(seller_info_cell.find_all("span")[1].contents[0]).strip() == "New seller"
-        if is_new_seller:
-            listing["seller_num_ratings"] = 0
-            listing["seller_avg_rating"] = None
-        else:
-            # the first 'a' element is the link to then seller, this one is the link to their reviewings
-            # we just extract the text content from that link
-            seller_num_ratings_elt = seller_info_cell.find_all("a")[1].contents[0]
-            listing["seller_num_ratings"] = int(seller_num_ratings_elt.split()[0].replace(",", "").strip())
-
-            # the seller rating is the second bold thing (their name is also in bold).
-            seller_avg_rating_elt = seller_info_cell.find_all("strong")[1].contents[0]
-            listing["seller_avg_rating"] = float(seller_avg_rating_elt.strip().split("%")[0])
-
+    for row in tbody.find_all("tr"):
         try:
-            listing["seller_ships_from"] = (
-                seller_info_cell.find("span", string="Ships From:").parent.contents[1].strip()
-            )
-        except IndexError:
-            # if we get an IndexError here it means the listing had no "Ships From:" country, => we don't continue
-            # parsing. The only times I've seen such listings in the past were scams...
+            listing = _parse_listing_row(row, release_id)
+        except (ParsingException, IndexError, AttributeError, ValueError) as exc:
+            logger.warning("Skipping a listing for release %s: %s", release_id, exc)
             continue
-
-        # extract price & shipping information
-        price_spans = item_price_cell.find("span", class_="price")
-        price_string: str = (
-            [elt for elt in price_spans.contents if elt.name is None][0].strip().replace("+", "").replace(",", "")
-        )
-        try:
-            currency, value = _parse_price_string(price_string)
-            listing["price"] = {"currency": currency, "value": value}
-        except PriceParsingException:
-            raise ParsingException(f"Couldn't parse currency from price_string {price_string} for release {release_id}")
-
-        shipping_string = item_price_cell.find("span", class_="item_shipping").contents[0].strip().replace("+", "")
-        shipping_currency_matches = re.findall(CURRENCY_REGEX, shipping_string)
-        shipping_currency = shipping_currency_matches[0] if len(shipping_currency_matches) > 0 else None
-        if shipping_currency is not None:
-            shipping_string = shipping_string.replace(shipping_currency, "").replace(",", "")
-            listing["price"]["shipping"] = {
-                "currency": dac.CURRENCIES[shipping_currency],
-                "value": float(shipping_string),
-            }
-
-        listings.append(dacite.from_dict(da_entities.Listing, listing))
+        if listing is not None:
+            listings.append(listing)
 
     return sorted(listings, key=lambda x: x.price.value)
+
+
+def _parse_listing_row(row: Tag, release_id: int) -> Optional[da_entities.Listing]:
+    """Parse one ``<tr>`` of the marketplace listings table into a `Listing`.
+
+    Returns `None` if the row isn't a real listing (e.g. doesn't carry a
+    "Ships From:" tag — that's typically scam-flagged listings we should skip
+    quietly).
+    """
+
+    listing: dict = {}
+
+    item_desc_cell = row.find("td", class_="item_description")
+    seller_info_cell = row.find("td", class_="seller_info")
+    item_price_cell = row.find("td", class_="item_price")
+    if item_desc_cell is None or seller_info_cell is None or item_price_cell is None:
+        return None
+
+    # Listing ID — derived from the listing's link.
+    anchor = item_desc_cell.find("a")
+    if anchor is None or "href" not in anchor.attrs:
+        return None
+    listing_url = anchor["href"]
+    listing["id"] = int(listing_url.split("/")[-1].split("?")[0])
+
+    paragraphs = item_desc_cell.find_all("p")
+    num_paragraphs = len(paragraphs)
+
+    # When `paragraphs` has 4 entries, the first is a hidden "Unavailable in
+    # <country>" notice; otherwise the listing is available everywhere.
+    listing["availability"] = None
+    if num_paragraphs == 4:
+        listing["availability"] = _first_text(paragraphs[0]) or None
+
+    item_condition_para = item_desc_cell.find("p", class_="item_condition")
+    if item_condition_para is None:
+        return None
+
+    conditions = [
+        da_entities.CONDITION_PARSER[s]
+        for s in item_condition_para.stripped_strings
+        if s in da_entities.CONDITION_PARSER
+    ]
+    if not conditions:
+        return None
+    # If sleeve condition is missing, fall back to NOT_GRADED.
+    conditions.append(da_entities.CONDITION.NOT_GRADED)
+    listing["media_condition"] = conditions[0]
+    listing["sleeve_condition"] = conditions[1]
+
+    # Seller's comment is the last paragraph; safe to be empty.
+    listing["comment"] = _first_text(paragraphs[-1]) if paragraphs else ""
+
+    # Seller metadata — second span is either "New seller" or contains the rating.
+    spans = seller_info_cell.find_all("span")
+    is_new_seller = len(spans) >= 2 and _first_text(spans[1]) == "New seller"
+    if is_new_seller:
+        listing["seller_num_ratings"] = 0
+        listing["seller_avg_rating"] = None
+    else:
+        anchors = seller_info_cell.find_all("a")
+        strongs = seller_info_cell.find_all("strong")
+        if len(anchors) < 2 or len(strongs) < 2:
+            return None
+        ratings_text = _first_text(anchors[1])
+        try:
+            listing["seller_num_ratings"] = int(ratings_text.split()[0].replace(",", ""))
+        except (IndexError, ValueError):
+            return None
+        rating_text = _first_text(strongs[1])
+        try:
+            listing["seller_avg_rating"] = float(rating_text.strip().split("%")[0])
+        except (IndexError, ValueError):
+            return None
+
+    ships_from_label = seller_info_cell.find("span", string="Ships From:")
+    if ships_from_label is None or ships_from_label.parent is None:
+        # No "Ships From:" — typically a scam listing; skip quietly.
+        return None
+    try:
+        listing["seller_ships_from"] = ships_from_label.parent.contents[1].strip()
+    except IndexError:
+        return None
+
+    # Price & shipping.
+    price_span = item_price_cell.find("span", class_="price")
+    if price_span is None:
+        return None
+    price_text_pieces = [elt for elt in price_span.contents if elt.name is None]
+    if not price_text_pieces:
+        return None
+    price_string = price_text_pieces[0].strip().replace("+", "").replace(",", "")
+    try:
+        currency, value = _parse_price_string(price_string)
+    except PriceParsingException as exc:
+        raise ParsingException(
+            f"Couldn't parse price {price_string!r} for release {release_id}"
+        ) from exc
+    listing["price"] = {"currency": currency, "value": value}
+
+    shipping_span = item_price_cell.find("span", class_="item_shipping")
+    if shipping_span is not None:
+        shipping_pieces = [elt for elt in shipping_span.contents if elt.name is None]
+        if shipping_pieces:
+            shipping = _parse_shipping(shipping_pieces[0])
+            if shipping is not None:
+                listing["price"]["shipping"] = shipping
+
+    return dacite.from_dict(da_entities.Listing, listing)

--- a/tests/test_scrape.py
+++ b/tests/test_scrape.py
@@ -165,15 +165,16 @@ def test_no_shipping_when_no_currency_in_span(parsed_listings):
     assert by_id[100000003].price.shipping is None
 
 
-def test_iso_coded_shipping_currently_dropped(parsed_listings):
-    """Documented limitation: shipping prices given as ISO codes (e.g.
-    ``+SEK 50.00``) are silently dropped because the shipping parser only
-    handles symbol currencies. Captured here so a future fix shows up as a
-    test diff.
+def test_iso_coded_shipping_is_parsed(parsed_listings):
+    """ISO-code-prefixed shipping (e.g. ``+SEK 50.00``) is now extracted correctly
+    by the dedicated shipping parser, not silently dropped.
     """
 
     by_id = {listing.id: listing for listing in parsed_listings}
-    assert by_id[100000004].price.shipping is None
+    s = by_id[100000004].price.shipping
+    assert s is not None
+    assert s.currency == "SEK"
+    assert s.value == 50.0
 
 
 def test_total_price_includes_shipping(parsed_listings):
@@ -214,3 +215,69 @@ def test_real_marketplace_html_parses_to_listings():
         assert listing.seller_ships_from
         assert isinstance(listing.media_condition, da_entities.CONDITION)
         assert isinstance(listing.sleeve_condition, da_entities.CONDITION)
+
+
+# -- Defensive parsing -----------------------------------------------------
+
+
+def test_scraper_returns_empty_for_html_without_marketplace_table():
+    """If Discogs returns an unexpected page (Cloudflare challenge, 404, etc.)
+    we should get back an empty list, not blow up.
+    """
+
+    listings = da_scrape.scrape_listings_from_marketplace("<html><body>nothing</body></html>", 1)
+    assert listings == []
+
+
+def test_scraper_skips_malformed_rows():
+    """A row missing the ships-from label, or with empty paragraphs, should be
+    skipped quietly rather than crash the whole parse.
+    """
+
+    html = """
+    <table class="mpitems">
+      <tbody>
+        <tr>
+          <td class="item_description">
+            <p><a href="/sell/item/999?ev=rb">empty seller comment</a></p>
+            <p class="item_condition">Media: <span>Very Good (VG)</span></p>
+            <p></p>
+          </td>
+          <td class="seller_info">
+            <ul><li>(no ships-from label)</li></ul>
+          </td>
+          <td class="item_price">
+            <span class="price">€10.00</span>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    """
+    listings = da_scrape.scrape_listings_from_marketplace(html, release_id=42)
+    assert listings == []  # the only row was skipped, but we didn't crash
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("+€4.50", {"currency": "EUR", "value": 4.5}),
+        ("+€4.50 shipping", {"currency": "EUR", "value": 4.5}),
+        ("+SEK 50.00", {"currency": "SEK", "value": 50.0}),
+        ("+SEK 50.00 shipping", {"currency": "SEK", "value": 50.0}),
+        ("+free shipping", None),
+        ("+about shipping", None),
+        ("", None),
+        ("shipping", None),
+    ],
+)
+def test_parse_shipping_handles_various_formats(raw, expected):
+    assert da_scrape._parse_shipping(raw) == expected
+
+
+def test_parse_price_string_handles_unparseable_numeric():
+    """Non-numeric text after a currency symbol should raise PriceParsingException
+    rather than letting `float()` throw a less helpful ValueError.
+    """
+
+    with pytest.raises(da_scrape.PriceParsingException):
+        da_scrape._parse_price_string("€not-a-number")


### PR DESCRIPTION
## Why
\`scrape.py\` was easy to crash on edge cases that don't fit the happy-path mental model.

## Fixes
1. **Empty seller-comment paragraphs** crashed at \`paragraphs[-1].contents[0]\`. Replaced with \`_first_text\` helper.
2. **ISO-code-prefixed shipping** (e.g. \`+SEK 50.00\`) was silently dropped — only symbol currencies were extracted. New \`_parse_shipping\` strips noise words and reuses \`_parse_price_string\`.
3. **Single malformed row killed the whole batch.** Each row is now wrapped in try/except; failures log a WARN and the parse continues.
4. \`scrape_listings_from_marketplace\` returns \`[]\` for HTML lacking the mpitems table (Cloudflare/404) instead of \`AttributeError\`.
5. \`_parse_price_string\` raises \`PriceParsingException\` (not \`ValueError\`) on bad numeric text; ISO fallback \`break\`s on first match.
6. \`_parse_listing_row\` extracted for readability.

## Tests
Updated obsolete \`test_iso_coded_shipping_currently_dropped\` (the bug is fixed). New: empty-table response, malformed-row skip, parametrised \`_parse_shipping\` cases, unparseable numeric.