### PR TITLE
Use chrome124 (not chrome131) as default curl_cffi impersonation

### DIFF
--- a/discogs_alert/client.py
+++ b/discogs_alert/client.py
@@ -148,7 +148,10 @@ class AnonClient(Client):
     """
 
     HTTP_TIMEOUT_SECONDS = 20
-    DEFAULT_IMPERSONATE = "chrome131"
+    # `chrome124` is the highest target supported across curl_cffi 0.5–0.7. Newer
+    # curl_cffi versions add e.g. `chrome131` — bump this when the project pins a
+    # newer curl_cffi floor, or pass `impersonate=` to override at runtime.
+    DEFAULT_IMPERSONATE = "chrome124"
 
     def __init__(self, user_agent: str, *args, impersonate: str = DEFAULT_IMPERSONATE, **kwargs):
         super().__init__(user_agent, *args, **kwargs)


### PR DESCRIPTION
Smoke-testing the live \`AnonClient\` against Discogs surfaced \`ImpersonateError: Impersonating chrome131 is not supported\` — the \`chrome131\` target landed in curl_cffi 0.8+; we pinned 0.7 in #93 which only goes up to \`chrome124\`. \`chrome124\` still bypasses Cloudflare cleanly. Inline comment documents the constraint so a future curl_cffi bump bumps the default too.