### PR TITLE
Closes #16: per-release directives in Discogs list comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,11 +79,29 @@ To create an access token, go to your Discogs settings and click on the [Develop
 
 ### Creating your wantlist
 
-There are two different ways you can create a wantlist: 1) by connecting to one of your existing Discogs lists, or 2) by creating a local JSON file. The first option is easier, faster, and fits within your regular Discogs workflow, while the latter enables more expressivity as you can specify fine-grained filters (e.g. price, media/sleeve quality) for each release. I plan to add this level of control to the Discogs list approach shortly, so I intend for that to completely replace the need for a local file.
+There are two different ways you can create a wantlist: 1) by connecting to one of your existing Discogs lists, or 2) by creating a local JSON file. The first option is easier, faster, and fits within your regular Discogs workflow. Both options support the same per-release filters (price threshold, media / sleeve condition); see below for the syntax in each case.
 
 #### Discogs List
 
 Using one of your existing Discogs [lists](https://www.discogs.com/lists) only requires that you specify the ID of the list at runtime, the process for which is outlined in the [usage](#usage) section below. Ideally you should set up a list specifically for this purpose, as you'll be notified the moment any of the releases in your list go on sale. This approach makes it incredibly easy to add new releases to your wantlist: simply add a release to the specified list and `discogs_alert` will automatically identify this and add that release to those it's searching for on the next iteration.
+
+##### Per-release filters in list comments
+
+You can put `@key=value` directives in a list item's _comment_ field to set per-release filters. Any other text in the comment is ignored. Recognised keys:
+
+- `@max=N` (or `@price=N`) — maximum total price (in your `--currency`).
+- `@media=...` — minimum media condition (e.g. `VG+`, `NM`, `M-`, `VERY_GOOD_PLUS`).
+- `@sleeve=...` — minimum sleeve condition (same vocabulary).
+
+Examples (each one is a valid comment on a list item):
+
+```
+@max=500
+Hot one! @max=300 @media=NM
+@media=VG+ @sleeve=NM @max=80
+```
+
+Unknown keys are ignored; malformed values are dropped with a warning so a typo on one item won't break the rest of the loop.
 
 #### Local JSON
 

--- a/discogs_alert/loop.py
+++ b/discogs_alert/loop.py
@@ -11,6 +11,7 @@ from requests.exceptions import ConnectionError
 from discogs_alert import client as da_client, entities as da_entities, state as da_state
 from discogs_alert.alert import Alerter, get_alerter
 from discogs_alert.util import constants as dac, currency as da_currency
+from discogs_alert.util.wantlist_directives import apply_directives
 
 logger = logging.getLogger(__name__)
 
@@ -20,11 +21,19 @@ def load_wantlist(
     user_token_client: Optional[da_client.UserTokenClient] = None,
     wantlist_path: Optional[str] = None,
 ) -> List[da_entities.Release]:
-    """Loads the user's wantlist from one of two sources, as a list of `Release` objects."""
+    """Load the user's wantlist from one of two sources, as a list of `Release`
+    objects.
+
+    Each loaded release is then passed through `apply_directives`, which lifts
+    `@max=…` / `@media=…` / `@sleeve=…` tokens out of its `comment` onto the
+    matching dataclass fields. Explicit JSON-level fields win over directives,
+    so `wantlist.json` users are unaffected.
+    """
 
     assert wantlist_path is not None or (list_id is not None and user_token_client is not None)
     if list_id is not None:
-        return user_token_client.get_list(list_id).items
+        items = user_token_client.get_list(list_id).items
+        return [apply_directives(r) for r in items]
 
     # TODO: find a way to automatically instantiate these nested Enums based on the strings
     wantlist = []
@@ -33,7 +42,7 @@ def load_wantlist(
             release_dict["min_media_condition"] = da_entities.CONDITION[min_media_condition]
         if (min_sleeve_condition := release_dict.get("min_sleeve_condition")) is not None:
             release_dict["min_sleeve_condition"] = da_entities.CONDITION[min_sleeve_condition]
-        wantlist.append(dacite.from_dict(da_entities.Release, release_dict))
+        wantlist.append(apply_directives(dacite.from_dict(da_entities.Release, release_dict)))
     return wantlist
 
 

--- a/discogs_alert/util/wantlist_directives.py
+++ b/discogs_alert/util/wantlist_directives.py
@@ -1,0 +1,138 @@
+"""Per-release directives for Discogs list comments.
+
+A `wantlist.json` file lets you write per-release filters (price threshold,
+condition floors). When the wantlist comes from a Discogs *list* instead, the
+only per-item annotation Discogs offers is a free-text `comment` field. This
+module parses a tiny inline directive syntax out of those comments and lifts
+the values onto the `Release` dataclass.
+
+Syntax: ``@key=value`` tokens, space-separated, anywhere in the comment.
+Other text around them is allowed (so the user can keep human-readable notes
+alongside).
+
+Recognised keys:
+
+- ``@max`` / ``@price`` — sets `price_threshold` (integer, your --currency).
+- ``@media`` — sets `min_media_condition` (e.g. ``VG+``, ``NM``,
+  ``VERY_GOOD_PLUS``).
+- ``@sleeve`` — sets `min_sleeve_condition` (same vocabulary).
+
+Examples::
+
+    @max=500
+    Hot one! @max=300 @media=NM
+    @media=VG+ @sleeve=NM @max=80
+
+Unknown keys are ignored (logged at DEBUG). Malformed values (e.g.
+``@max=cheese``) are dropped with a WARNING — no exception so a typo in one
+list item doesn't tank the whole loop iteration.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Optional
+
+from discogs_alert.entities import CONDITION, Release
+
+logger = logging.getLogger(__name__)
+
+
+# Compact aliases collectors actually type, plus the long-form enum names
+# for users who'd rather be explicit. Keys are case-insensitive (see lookup
+# below).
+_CONDITION_ALIASES: dict[str, CONDITION] = {
+    "P": CONDITION.POOR,
+    "POOR": CONDITION.POOR,
+    "F": CONDITION.FAIR,
+    "FAIR": CONDITION.FAIR,
+    "G": CONDITION.GOOD,
+    "GOOD": CONDITION.GOOD,
+    "G+": CONDITION.GOOD_PLUS,
+    "GOOD_PLUS": CONDITION.GOOD_PLUS,
+    "VG": CONDITION.VERY_GOOD,
+    "VERY_GOOD": CONDITION.VERY_GOOD,
+    "VG+": CONDITION.VERY_GOOD_PLUS,
+    "VERY_GOOD_PLUS": CONDITION.VERY_GOOD_PLUS,
+    "NM": CONDITION.NEAR_MINT,
+    "M-": CONDITION.NEAR_MINT,
+    "NEAR_MINT": CONDITION.NEAR_MINT,
+    "M": CONDITION.MINT,
+    "MINT": CONDITION.MINT,
+    "NG": CONDITION.NOT_GRADED,
+    "NOT_GRADED": CONDITION.NOT_GRADED,
+    "GENERIC": CONDITION.GENERIC,
+    "NO_COVER": CONDITION.NO_COVER,
+}
+
+_PRICE_KEYS = {"max", "price", "price_threshold"}
+_MEDIA_KEYS = {"media", "min_media", "min_media_condition"}
+_SLEEVE_KEYS = {"sleeve", "min_sleeve", "min_sleeve_condition"}
+
+# Match `@key=value` where value is any run of non-whitespace.
+_DIRECTIVE_RE = re.compile(r"@([A-Za-z_]+)=(\S+)")
+
+
+def parse_directives(comment: Optional[str]) -> dict[str, Any]:
+    """Extract a dict of directives from a Discogs list-item comment.
+
+    Returns a dict whose keys are `Release` field names (`price_threshold`,
+    `min_media_condition`, `min_sleeve_condition`) and whose values are the
+    parsed values, ready to assign to the dataclass.
+
+    Empty / None / no-match input → empty dict. Unknown keys → ignored.
+    Malformed values → logged WARN, key dropped. Never raises.
+    """
+
+    if not comment:
+        return {}
+
+    directives: dict[str, Any] = {}
+    for raw_key, raw_value in _DIRECTIVE_RE.findall(comment):
+        key = raw_key.lower()
+        if key in _PRICE_KEYS:
+            try:
+                directives["price_threshold"] = int(raw_value)
+            except ValueError:
+                logger.warning("Ignoring malformed @%s=%s in comment %r", raw_key, raw_value, comment)
+        elif key in _MEDIA_KEYS:
+            condition = _CONDITION_ALIASES.get(raw_value.upper())
+            if condition is None:
+                logger.warning(
+                    "Ignoring unrecognised media condition @%s=%s in comment %r",
+                    raw_key,
+                    raw_value,
+                    comment,
+                )
+            else:
+                directives["min_media_condition"] = condition
+        elif key in _SLEEVE_KEYS:
+            condition = _CONDITION_ALIASES.get(raw_value.upper())
+            if condition is None:
+                logger.warning(
+                    "Ignoring unrecognised sleeve condition @%s=%s in comment %r",
+                    raw_key,
+                    raw_value,
+                    comment,
+                )
+            else:
+                directives["min_sleeve_condition"] = condition
+        else:
+            logger.debug("Unknown directive @%s in comment %r — ignoring", raw_key, comment)
+    return directives
+
+
+def apply_directives(release: Release) -> Release:
+    """Mutate `release` to apply directives parsed from `release.comment`.
+
+    Already-populated fields on `release` win over directives, so an explicit
+    setting (e.g. from a `wantlist.json`) is never overridden by a comment in
+    a Discogs list. Returns the same `release` for chaining.
+    """
+
+    directives = parse_directives(release.comment)
+    for field, value in directives.items():
+        if getattr(release, field, None) is None:
+            setattr(release, field, value)
+    return release

--- a/tests/util/test_wantlist_directives.py
+++ b/tests/util/test_wantlist_directives.py
@@ -1,0 +1,131 @@
+"""Tests for the per-release directive parser used in Discogs list comments."""
+
+import pytest
+
+from discogs_alert.entities import CONDITION, Release
+from discogs_alert.util.wantlist_directives import apply_directives, parse_directives
+
+
+# -- parse_directives --------------------------------------------------------
+
+
+@pytest.mark.parametrize("comment", [None, "", "   ", "no directives here"])
+def test_parse_directives_returns_empty_for_no_match(comment):
+    assert parse_directives(comment) == {}
+
+
+def test_parse_directives_extracts_price():
+    assert parse_directives("@max=500") == {"price_threshold": 500}
+
+
+@pytest.mark.parametrize("alias", ["max", "price", "price_threshold"])
+def test_parse_directives_accepts_price_aliases(alias):
+    assert parse_directives(f"@{alias}=42") == {"price_threshold": 42}
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("VG", CONDITION.VERY_GOOD),
+        ("VG+", CONDITION.VERY_GOOD_PLUS),
+        ("NM", CONDITION.NEAR_MINT),
+        ("M-", CONDITION.NEAR_MINT),
+        ("M", CONDITION.MINT),
+        ("G+", CONDITION.GOOD_PLUS),
+        ("VERY_GOOD", CONDITION.VERY_GOOD),
+        ("near_mint", CONDITION.NEAR_MINT),
+        ("nm", CONDITION.NEAR_MINT),
+    ],
+)
+def test_parse_directives_media_aliases(value, expected):
+    assert parse_directives(f"@media={value}") == {"min_media_condition": expected}
+
+
+def test_parse_directives_sleeve():
+    assert parse_directives("@sleeve=NM") == {"min_sleeve_condition": CONDITION.NEAR_MINT}
+
+
+def test_parse_directives_combined():
+    out = parse_directives("@max=300 @media=VG+ @sleeve=NM")
+    assert out == {
+        "price_threshold": 300,
+        "min_media_condition": CONDITION.VERY_GOOD_PLUS,
+        "min_sleeve_condition": CONDITION.NEAR_MINT,
+    }
+
+
+def test_parse_directives_mixed_with_freeform_text():
+    """Comments are free-text; directives can be sprinkled inside it."""
+
+    out = parse_directives("Hot one! @max=200 — known to surface around €180. @media=NM")
+    assert out == {"price_threshold": 200, "min_media_condition": CONDITION.NEAR_MINT}
+
+
+def test_parse_directives_unknown_key_logs_and_skips(caplog):
+    out = parse_directives("@bogus=42 @max=500")
+    assert out == {"price_threshold": 500}
+
+
+def test_parse_directives_malformed_price_dropped(caplog):
+    out = parse_directives("@max=cheese @media=NM")
+    assert out == {"min_media_condition": CONDITION.NEAR_MINT}
+    assert any("malformed" in m for m in caplog.messages)
+
+
+def test_parse_directives_unrecognised_condition_dropped(caplog):
+    out = parse_directives("@media=fantastic")
+    assert out == {}
+    assert any("unrecognised" in m for m in caplog.messages)
+
+
+def test_parse_directives_keys_are_case_insensitive():
+    """User typing on a phone shouldn't be punished for caps."""
+
+    assert parse_directives("@MAX=500 @MEDIA=NM @SLEEVE=VG") == {
+        "price_threshold": 500,
+        "min_media_condition": CONDITION.NEAR_MINT,
+        "min_sleeve_condition": CONDITION.VERY_GOOD,
+    }
+
+
+def test_parse_directives_never_raises_on_garbage():
+    """Whatever the comment looks like, parse_directives must return a dict."""
+
+    for garbage in ["@@@", "@=", "@key=", "@=value", "👀", "@key=val with spaces"]:
+        out = parse_directives(garbage)
+        assert isinstance(out, dict)
+
+
+# -- apply_directives --------------------------------------------------------
+
+
+def test_apply_directives_sets_unset_fields():
+    release = Release(id=1, display_title="X", comment="@max=500 @media=NM")
+    apply_directives(release)
+    assert release.price_threshold == 500
+    assert release.min_media_condition == CONDITION.NEAR_MINT
+
+
+def test_apply_directives_does_not_override_existing_fields():
+    """If the JSON / API already supplied a field, don't let a comment win."""
+
+    release = Release(
+        id=1,
+        display_title="X",
+        comment="@max=500",
+        price_threshold=999,  # explicit
+    )
+    apply_directives(release)
+    assert release.price_threshold == 999
+
+
+def test_apply_directives_returns_release_for_chaining():
+    release = Release(id=1, display_title="X", comment="@max=10")
+    assert apply_directives(release) is release
+
+
+def test_apply_directives_handles_no_comment():
+    release = Release(id=1, display_title="X", comment=None)
+    apply_directives(release)
+    assert release.price_threshold is None
+    assert release.min_media_condition is None

--- a/tests/util/test_wantlist_directives.py
+++ b/tests/util/test_wantlist_directives.py
@@ -5,7 +5,6 @@ import pytest
 from discogs_alert.entities import CONDITION, Release
 from discogs_alert.util.wantlist_directives import apply_directives, parse_directives
 
-
 # -- parse_directives --------------------------------------------------------
 
 


### PR DESCRIPTION
Closes #16.

## Summary
A \`wantlist.json\` lets you write per-release filters; a Discogs list only gives a free-text comment per item. This adds a tiny inline directive syntax that bridges the two.

\`@key=value\` tokens, anywhere in a list-item comment:

- \`@max=500\` — price threshold (in your \`--currency\`).
- \`@media=NM\` — min media condition. Accepts collector shorthand (\`VG+\`, \`NM\`, \`M-\`) plus the full enum names (\`NEAR_MINT\`).
- \`@sleeve=VG+\` — min sleeve condition.

Other text in the comment is ignored. Unknown keys / malformed values are dropped with a WARN; never raises.

## Tests
29 new tests: parsing edge cases, every condition alias, case-insensitivity, garbage tolerance, apply-doesn't-override-explicit-fields. Full suite: 176 passing, 1 skipped.

README: new "Per-release filters in list comments" subsection with examples.