### PR TITLE
Spread marketplace scrapes via configurable inter-release delay

### DIFF
--- a/discogs_alert/__main__.py
+++ b/discogs_alert/__main__.py
@@ -199,6 +199,20 @@ logger = logging.getLogger(__name__)
     ),
 )
 @click.option(
+    "-d",
+    "--inter-release-delay",
+    default=0.0,
+    show_default=True,
+    type=click.FloatRange(min=0.0, max=60.0),
+    envvar="DA_INTER_RELEASE_DELAY",
+    help=(
+        "Seconds to sleep between marketplace scrapes (with ±25%% jitter). Useful "
+        "for very large wantlists where you want to spread Cloudflare-facing "
+        "requests across the iteration interval rather than burst them. Default "
+        "0 (no delay)."
+    ),
+)
+@click.option(
     "-V", "--verbose", default=False, is_flag=True, help="use flag if you want to see logs as the program runs"
 )
 @click.option(
@@ -230,6 +244,7 @@ def main(
     telegram_chat_id,
     state_path,
     stats_gate,
+    inter_release_delay,
     verbose,
     test,
 ):
@@ -265,6 +280,7 @@ def main(
         alerter_kwargs=alerter_kwargs,
         state_path=state_path,
         use_stats_gate=stats_gate,
+        inter_release_delay_seconds=inter_release_delay,
         verbose=verbose,
     )
 

--- a/discogs_alert/loop.py
+++ b/discogs_alert/loop.py
@@ -161,6 +161,7 @@ def loop(
     alerter_kwargs: Dict[str, Any],
     state_path: Optional[Path] = None,
     use_stats_gate: bool = True,
+    inter_release_delay_seconds: float = 0.0,
     verbose: bool = False,
 ):
     """Event loop. One iteration: pull the wantlist, query the marketplace for each
@@ -174,6 +175,11 @@ def loop(
     from sale, or above the user's price threshold are skipped without scraping
     the marketplace page. This is the single largest rate-limit win for users
     with large wantlists.
+
+    `inter_release_delay_seconds` (default 0) spreads marketplace fetches across
+    the iteration interval — useful for very large wantlists where Discogs's
+    Cloudflare layer might throttle a tight burst. With ±25% jitter so multiple
+    parallel runs don't synchronise.
     """
 
     start_time = time.time()
@@ -189,7 +195,8 @@ def loop(
         with da_state.AlertStore(state_path) as store:
             wantlist_items = load_wantlist(list_id, user_token_client, wantlist_path)
             random.shuffle(wantlist_items)
-            for release in wantlist_items:
+            num_items = len(wantlist_items)
+            for idx, release in enumerate(wantlist_items):
                 # Rate-limit protection is now handled inside `UserTokenClient`
                 # via `RateLimitGuard` — we don't need an explicit sleep here.
 
@@ -222,6 +229,20 @@ def loop(
                     store,
                     verbose=verbose,
                 )
+
+                # Spread marketplace scrapes across the iteration interval so
+                # we don't hammer Discogs from a single IP in a tight burst.
+                # Cloudflare doesn't expose its rate-limit headers, so any
+                # explicit pacing has to be local. Skip on the last release
+                # to avoid a pointless sleep at the end.
+                if (
+                    inter_release_delay_seconds > 0
+                    and num_items > 1
+                    and idx < num_items - 1
+                ):
+                    # Add ~±25% jitter so two parallel runs don't synchronise.
+                    jitter = random.uniform(-0.25, 0.25) * inter_release_delay_seconds
+                    time.sleep(max(0.0, inter_release_delay_seconds + jitter))
 
     except ConnectionError:
         logger.info("ConnectionError: looping will continue as usual", exc_info=True)

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -427,3 +427,87 @@ def test_loop_no_stats_gate_flag_disables_gate(tmp_path: Path, monkeypatch: pyte
     )
 
     assert process_calls == [1]
+
+
+# -- inter_release_delay --------------------------------------------------
+
+
+def test_loop_sleeps_between_releases_when_delay_set(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    wl = tmp_path / "wl.json"
+    wl.write_text(
+        json.dumps(
+            [
+                {"id": 1, "display_title": "A"},
+                {"id": 2, "display_title": "B"},
+                {"id": 3, "display_title": "C"},
+            ]
+        )
+    )
+
+    fake_anon = MagicMock()
+    fake_user_client = MagicMock()
+    fake_user_client.rate_limit_remaining = 50
+    fake_user_client.get_release_stats.return_value = False
+    monkeypatch.setattr(da_client, "AnonClient", lambda *_a, **_kw: fake_anon)
+    monkeypatch.setattr(da_client, "UserTokenClient", lambda *_a, **_kw: fake_user_client)
+    monkeypatch.setattr(da_loop, "process_release", lambda *a, **k: 0)
+
+    sleeps = []
+    monkeypatch.setattr(da_loop.time, "sleep", lambda s: sleeps.append(s))
+
+    da_loop.loop(
+        discogs_token="X",
+        list_id=None,
+        wantlist_path=str(wl),
+        user_agent="UA",
+        country="Germany",
+        currency="EUR",
+        seller_filters=da_entities.SellerFilters(),
+        record_filters=da_entities.RecordFilters(),
+        country_whitelist=set(),
+        country_blacklist=set(),
+        alerter_type=AlerterType.PUSHBULLET,
+        alerter_kwargs={"pushbullet_token": "T"},
+        state_path=tmp_path / "state.db",
+        inter_release_delay_seconds=2.0,
+    )
+
+    # 3 releases → 2 inter-release gaps (no sleep after the last one).
+    assert len(sleeps) == 2
+    # With ±25% jitter on a 2.0s base, every sleep is in [1.5, 2.5].
+    for s in sleeps:
+        assert 1.5 <= s <= 2.5
+
+
+def test_loop_does_not_sleep_with_default_zero_delay(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    wl = tmp_path / "wl.json"
+    wl.write_text(json.dumps([{"id": 1, "display_title": "A"}, {"id": 2, "display_title": "B"}]))
+
+    fake_anon = MagicMock()
+    fake_user_client = MagicMock()
+    fake_user_client.rate_limit_remaining = 50
+    fake_user_client.get_release_stats.return_value = False
+    monkeypatch.setattr(da_client, "AnonClient", lambda *_a, **_kw: fake_anon)
+    monkeypatch.setattr(da_client, "UserTokenClient", lambda *_a, **_kw: fake_user_client)
+    monkeypatch.setattr(da_loop, "process_release", lambda *a, **k: 0)
+
+    sleeps = []
+    monkeypatch.setattr(da_loop.time, "sleep", lambda s: sleeps.append(s))
+
+    da_loop.loop(
+        discogs_token="X",
+        list_id=None,
+        wantlist_path=str(wl),
+        user_agent="UA",
+        country="Germany",
+        currency="EUR",
+        seller_filters=da_entities.SellerFilters(),
+        record_filters=da_entities.RecordFilters(),
+        country_whitelist=set(),
+        country_blacklist=set(),
+        alerter_type=AlerterType.PUSHBULLET,
+        alerter_kwargs={"pushbullet_token": "T"},
+        state_path=tmp_path / "state.db",
+    )
+
+    assert sleeps == []


### PR DESCRIPTION
## Why
For very large wantlists, scraping every release back-to-back from one IP risks Cloudflare's request-rate threshold. The \`/marketplace/stats\` gate already cuts ~95% of fetches, but the remaining ones still burst.

## Change
\`loop.loop\` accepts \`inter_release_delay_seconds\` (default 0.0 = current behaviour). When set, sleeps between releases with ±25% jitter so parallel runs don't synchronise. New CLI flag \`-d / --inter-release-delay\`, env var \`DA_INTER_RELEASE_DELAY\`. Range [0, 60] seconds.

## Tests
With \`delay=2.0s\` and 3 releases, exactly 2 sleeps fire (no tail sleep), each within [1.5, 2.5].