### PR TITLE
Make alerters pluggable via Python entry points

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,10 +134,16 @@ To use Telegram you first need to create a custom bot, the easiest mechanism for
 ```
 You need to find your `CHAT_ID` as indicated above and save that. You may have to send a few "/start" messages to your bot before you get a response that looks like this. Once you've got your CHAT ID as well as your API token, you're all good to go!
 
-#### More coming soon ...
+#### Adding more alerters (plugin authors)
 
-I plan to add more alerting options as soon as possible! Please feel free to open a PR if you have a particular service
-in mind that you'd like to support.
+`discogs_alert` discovers alerters dynamically via the `discogs_alert.alerters` Python entry-point group. To ship a new alerter as a separate package, subclass `discogs_alert.alert.base.Alerter` and register the class in your package's `pyproject.toml`:
+
+```toml
+[project.entry-points."discogs_alert.alerters"]
+ntfy = "discogs_alert_ntfy:NtfyAlerter"
+```
+
+After `pip install discogs-alert-ntfy`, `discogs_alert --alerter-type=NTFY` is selectable. The entry-point name (uppercased) becomes the value of `--alerter-type`. Your alerter is responsible for reading its own config (env vars, a config file, etc.) — built-in CLI flags like `-pt/--pushbullet-token` are only for built-ins.
 
 ## Usage
 

--- a/discogs_alert/__main__.py
+++ b/discogs_alert/__main__.py
@@ -143,15 +143,18 @@ logger = logging.getLogger(__name__)
     "--alerter-type",
     required=True,
     envvar="DA_ALERTER_TYPE",
-    type=da_click.EnumChoice(da_alert.AlerterType),
+    # Dynamic Choice — built-in names plus any plugin alerters registered via
+    # the `discogs_alert.alerters` entry-point group. Always shows the current
+    # registered set in `--help`.
+    type=click.Choice(da_alert.alerter_names(), case_sensitive=False),
     help="Your choice of alerting service. Please see the Alerters section in the README for more information",
 )
 @click.option(
     "-pt",
     "--pushbullet-token",
     cls=da_click.RequiredIf,
-    required_if=lambda x: x["alerter_type"] == da_alert.AlerterType.PUSHBULLET,
-    required_if_str="alerter_type=AlerterType.PUSHBULLET",
+    required_if=lambda x: str(x.get("alerter_type", "")).upper() == "PUSHBULLET",
+    required_if_str="alerter_type=PUSHBULLET",
     type=str,
     envvar="DA_PUSHBULLET_TOKEN",
     help="token for pushbullet notification service.",
@@ -160,8 +163,8 @@ logger = logging.getLogger(__name__)
     "-tt",
     "--telegram-token",
     cls=da_click.RequiredIf,
-    required_if=lambda x: x["alerter_type"] == da_alert.AlerterType.TELEGRAM,
-    required_if_str="alerter_type=AlerterType.TELEGRAM",
+    required_if=lambda x: str(x.get("alerter_type", "")).upper() == "TELEGRAM",
+    required_if_str="alerter_type=TELEGRAM",
     type=str,
     envvar="DA_TELEGRAM_TOKEN",
     help="token for telegram bot notification service.",
@@ -170,8 +173,8 @@ logger = logging.getLogger(__name__)
     "-tci",
     "--telegram-chat-id",
     cls=da_click.RequiredIf,
-    required_if=lambda x: x["alerter_type"] == da_alert.AlerterType.TELEGRAM,
-    required_if_str="alerter_type=AlerterType.TELEGRAM",
+    required_if=lambda x: str(x.get("alerter_type", "")).upper() == "TELEGRAM",
+    required_if_str="alerter_type=TELEGRAM",
     type=str,
     envvar="DA_TELEGRAM_CHAT_ID",
     help="chat ID for telegram bot notification service.",
@@ -242,13 +245,18 @@ def main(
     if list_id is not None and wantlist_path is not None:
         list_id = None
 
-    # organise only those kwargs necessary for the alerter being used
-    if alerter_type == da_alert.AlerterType.PUSHBULLET:
+    # `alerter_type` arrives as a string from `click.Choice`. Built-in alerters
+    # have explicit CLI options for their kwargs; plugin alerters (registered
+    # via the `discogs_alert.alerters` entry point) read their own config from
+    # env vars or wherever they like — we just pass an empty kwargs dict.
+    alerter_type = alerter_type.upper()
+    if alerter_type == "PUSHBULLET":
         alerter_kwargs = {"pushbullet_token": pushbullet_token}
-    elif alerter_type == da_alert.AlerterType.TELEGRAM:
+    elif alerter_type == "TELEGRAM":
         alerter_kwargs = {"telegram_token": telegram_token, "telegram_chat_id": telegram_chat_id}
     else:
-        raise ValueError("We should never get here")
+        # Plugin alerter — its constructor is responsible for its own config.
+        alerter_kwargs = {}
 
     loop_kwargs = dict(
         discogs_token=discogs_token,

--- a/discogs_alert/alert/__init__.py
+++ b/discogs_alert/alert/__init__.py
@@ -1,23 +1,136 @@
+"""Alerter discovery and dispatch.
+
+Built-in alerters (Pushbullet, Telegram) are registered directly. Third-party
+alerters can register themselves via the ``discogs_alert.alerters`` entry-point
+group in their `pyproject.toml`::
+
+    [project.entry-points."discogs_alert.alerters"]
+    ntfy = "discogs_alert_ntfy:NtfyAlerter"
+
+After ``pip install discogs-alert-ntfy``, the alerter shows up in
+``discover_alerters()`` and can be selected via ``--alerter-type=NTFY``.
+
+The legacy ``AlerterType`` IntEnum is kept for back-compat with existing call
+sites, but the canonical "type" is now the alerter's registered name (a
+string). Pass the name as either a string or an `AlerterType` member; both are
+accepted.
+"""
+
+from __future__ import annotations
+
 import enum
-from typing import Any, Dict
+import logging
+from importlib.metadata import entry_points, EntryPoints
+from typing import Any, Dict, List, Type, Union
 
 from discogs_alert.alert.base import Alerter
 from discogs_alert.alert.pushbullet import PushbulletAlerter
 from discogs_alert.alert.telegram import TelegramAlerter
 
+logger = logging.getLogger(__name__)
+
+ENTRY_POINT_GROUP = "discogs_alert.alerters"
+
+# Built-in alerters — always available, regardless of entry-point installation.
+_BUILTIN_ALERTERS: Dict[str, Type[Alerter]] = {
+    "PUSHBULLET": PushbulletAlerter,
+    "TELEGRAM": TelegramAlerter,
+}
+
 
 @enum.unique
 class AlerterType(enum.IntEnum):
+    """Built-in alerter identifiers.
+
+    Kept for back-compat — `discogs_alert` accepts string names and these enum
+    members interchangeably. Third-party alerters registered via entry points
+    don't appear here; refer to them by name (e.g. ``"NTFY"``).
+    """
+
     PUSHBULLET = enum.auto()
     TELEGRAM = enum.auto()
 
 
-def get_alerter(alerter_type: AlerterType, alerter_kwargs: Dict[str, Any]) -> Alerter:
-    if alerter_type == AlerterType.PUSHBULLET:
-        alerter_cls = PushbulletAlerter
-    elif alerter_type == AlerterType.TELEGRAM:
-        alerter_cls = TelegramAlerter
-    else:
-        raise ValueError("`alerter_type` must be a valid AlerterType value")
+def _load_entry_point_alerters() -> Dict[str, Type[Alerter]]:
+    """Discover alerter classes registered against the `discogs_alert.alerters`
+    entry-point group. Returns a mapping ``{name.upper(): AlerterClass}``.
 
-    return alerter_cls(**alerter_kwargs)
+    Errors loading individual entry points are logged and the entry skipped —
+    one broken plugin shouldn't take down the whole alerter registry.
+    """
+
+    discovered: Dict[str, Type[Alerter]] = {}
+    try:
+        eps: EntryPoints = entry_points(group=ENTRY_POINT_GROUP)
+    except Exception:
+        logger.exception("Failed to enumerate entry points")
+        return discovered
+    for ep in eps:
+        try:
+            cls = ep.load()
+        except Exception:
+            logger.exception("Failed to load alerter entry point %r", ep.name)
+            continue
+        if not isinstance(cls, type) or not issubclass(cls, Alerter):
+            logger.warning(
+                "Alerter entry point %r resolves to %r, which is not an `Alerter` subclass — skipping",
+                ep.name,
+                cls,
+            )
+            continue
+        discovered[ep.name.upper()] = cls
+    return discovered
+
+
+def discover_alerters() -> Dict[str, Type[Alerter]]:
+    """Return the full alerter registry: built-ins, then any entry-point
+    additions. Entry points may NOT shadow built-ins (built-ins always win).
+
+    The result is recomputed each call so newly-installed plugins are picked up
+    without restarting the process — `entry_points()` is fast enough that the
+    cost is negligible.
+    """
+
+    registry: Dict[str, Type[Alerter]] = dict(_BUILTIN_ALERTERS)
+    for name, cls in _load_entry_point_alerters().items():
+        if name in registry:
+            logger.warning(
+                "Entry-point alerter %r conflicts with a built-in — keeping the built-in", name
+            )
+            continue
+        registry[name] = cls
+    return registry
+
+
+def alerter_names() -> List[str]:
+    """Sorted list of all registered alerter names. Used by the CLI to populate
+    the `--alerter-type` Choice dynamically.
+    """
+
+    return sorted(discover_alerters().keys())
+
+
+def _normalise(name_or_type: Union[str, AlerterType]) -> str:
+    if isinstance(name_or_type, AlerterType):
+        return name_or_type.name
+    return str(name_or_type).upper()
+
+
+def get_alerter(alerter_type: Union[str, AlerterType], alerter_kwargs: Dict[str, Any]) -> Alerter:
+    """Instantiate the alerter named `alerter_type` with the given kwargs.
+
+    Args:
+        alerter_type: an `AlerterType` member, or a string name (case-insensitive).
+        alerter_kwargs: kwargs forwarded to the alerter's constructor.
+
+    Raises:
+        ValueError: if the name doesn't match any registered alerter.
+    """
+
+    name = _normalise(alerter_type)
+    registry = discover_alerters()
+    if name not in registry:
+        raise ValueError(
+            f"Unknown alerter {name!r}; available: {sorted(registry)}"
+        )
+    return registry[name](**alerter_kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,17 @@ ruff = "^0.6"
 requires = ["poetry-core>=1.9.0"]
 build-backend = "poetry.core.masonry.api"
 
+# Built-in alerters are registered both here (so `pip install discogs-alert`
+# exposes them via entry points) and in `discogs_alert.alert.__init__._BUILTIN_ALERTERS`
+# (so editable installs and tests work without entry-point installation). Third-
+# party alerters can register themselves under the same group:
+#
+#     [project.entry-points."discogs_alert.alerters"]
+#     ntfy = "discogs_alert_ntfy:NtfyAlerter"
+[tool.poetry.plugins."discogs_alert.alerters"]
+PUSHBULLET = "discogs_alert.alert.pushbullet:PushbulletAlerter"
+TELEGRAM = "discogs_alert.alert.telegram:TelegramAlerter"
+
 [tool.poetry2conda]
 name = "da"
 

--- a/tests/notify/test_alert_registry.py
+++ b/tests/notify/test_alert_registry.py
@@ -1,0 +1,144 @@
+"""Tests for the alerter registry / dispatch in `discogs_alert.alert`."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from discogs_alert import alert as da_alert
+from discogs_alert.alert.base import Alerter
+from discogs_alert.alert.pushbullet import PushbulletAlerter
+from discogs_alert.alert.telegram import TelegramAlerter
+
+
+def test_builtins_are_always_registered():
+    registry = da_alert.discover_alerters()
+    assert registry["PUSHBULLET"] is PushbulletAlerter
+    assert registry["TELEGRAM"] is TelegramAlerter
+
+
+def test_alerter_names_includes_builtins():
+    names = da_alert.alerter_names()
+    assert "PUSHBULLET" in names
+    assert "TELEGRAM" in names
+
+
+def test_get_alerter_by_string_name():
+    alerter = da_alert.get_alerter("PUSHBULLET", {"pushbullet_token": "T"})
+    assert isinstance(alerter, PushbulletAlerter)
+
+
+def test_get_alerter_string_name_is_case_insensitive():
+    alerter = da_alert.get_alerter("pushbullet", {"pushbullet_token": "T"})
+    assert isinstance(alerter, PushbulletAlerter)
+
+
+def test_get_alerter_by_enum_member_still_works():
+    """Backward compat: code using the AlerterType enum from before keeps working."""
+
+    alerter = da_alert.get_alerter(da_alert.AlerterType.TELEGRAM, {"telegram_token": "T", "telegram_chat_id": "1"})
+    assert isinstance(alerter, TelegramAlerter)
+
+
+def test_get_alerter_unknown_name_raises():
+    with pytest.raises(ValueError) as exc:
+        da_alert.get_alerter("DOESNOTEXIST", {})
+    assert "DOESNOTEXIST" in str(exc.value)
+
+
+def test_entry_point_alerter_is_discovered(monkeypatch: pytest.MonkeyPatch):
+    """A third-party alerter registered via the `discogs_alert.alerters`
+    entry-point group should appear in `discover_alerters()`.
+    """
+
+    class FakeAlerter(Alerter):
+        def __init__(self, **kwargs: Any) -> None:
+            self.kwargs = kwargs
+
+        def send_alert(self, message_title: str, message_body: str) -> bool:
+            return True
+
+    fake_ep = MagicMock()
+    fake_ep.name = "fake"
+    fake_ep.load.return_value = FakeAlerter
+
+    def fake_entry_points(group=None):
+        if group == da_alert.ENTRY_POINT_GROUP:
+            return [fake_ep]
+        return []
+
+    monkeypatch.setattr(da_alert, "entry_points", fake_entry_points)
+
+    registry = da_alert.discover_alerters()
+    assert registry["FAKE"] is FakeAlerter
+
+    alerter = da_alert.get_alerter("FAKE", {"some": "config"})
+    assert isinstance(alerter, FakeAlerter)
+    assert alerter.kwargs == {"some": "config"}
+
+
+def test_entry_point_cannot_shadow_builtin(monkeypatch: pytest.MonkeyPatch, caplog):
+    """A plugin trying to register under a built-in name (e.g. ``PUSHBULLET``)
+    should be ignored — built-ins always win.
+    """
+
+    class FakePushbullet(Alerter):
+        def send_alert(self, message_title: str, message_body: str) -> bool:
+            return False
+
+    fake_ep = MagicMock()
+    fake_ep.name = "PUSHBULLET"  # tries to shadow built-in
+    fake_ep.load.return_value = FakePushbullet
+
+    def fake_entry_points(group=None):
+        if group == da_alert.ENTRY_POINT_GROUP:
+            return [fake_ep]
+        return []
+
+    monkeypatch.setattr(da_alert, "entry_points", fake_entry_points)
+
+    registry = da_alert.discover_alerters()
+    assert registry["PUSHBULLET"] is PushbulletAlerter  # built-in retained
+
+
+def test_entry_point_load_failure_is_logged_and_skipped(monkeypatch: pytest.MonkeyPatch, caplog):
+    fake_ep = MagicMock()
+    fake_ep.name = "broken"
+    fake_ep.load.side_effect = ImportError("missing-package")
+
+    def fake_entry_points(group=None):
+        if group == da_alert.ENTRY_POINT_GROUP:
+            return [fake_ep]
+        return []
+
+    monkeypatch.setattr(da_alert, "entry_points", fake_entry_points)
+
+    registry = da_alert.discover_alerters()
+    assert "BROKEN" not in registry
+    # Built-ins still present
+    assert "PUSHBULLET" in registry
+
+
+def test_entry_point_non_alerter_subclass_is_skipped(monkeypatch: pytest.MonkeyPatch):
+    """If someone registers a class that doesn't subclass `Alerter`, refuse to
+    add it — that's a contract violation.
+    """
+
+    class NotAnAlerter:
+        pass
+
+    fake_ep = MagicMock()
+    fake_ep.name = "wrongtype"
+    fake_ep.load.return_value = NotAnAlerter
+
+    def fake_entry_points(group=None):
+        if group == da_alert.ENTRY_POINT_GROUP:
+            return [fake_ep]
+        return []
+
+    monkeypatch.setattr(da_alert, "entry_points", fake_entry_points)
+
+    registry = da_alert.discover_alerters()
+    assert "WRONGTYPE" not in registry

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import pytest
 from click.testing import CliRunner
 
-from discogs_alert import __main__ as da_main, alert as da_alert, entities as da_entities, loop as da_loop
+from discogs_alert import __main__ as da_main, entities as da_entities, loop as da_loop
 
 
 @pytest.fixture
@@ -51,7 +51,7 @@ def test_cli_runs_with_minimal_required_args(stub_loop, wantlist_file):
     assert result.exit_code == 0, result.output
     assert stub_loop["discogs_token"] == "TOK"
     assert stub_loop["wantlist_path"] == str(wantlist_file)
-    assert stub_loop["alerter_type"] == da_alert.AlerterType.PUSHBULLET
+    assert stub_loop["alerter_type"] == "PUSHBULLET"
     assert stub_loop["alerter_kwargs"] == {"pushbullet_token": "PB"}
     assert stub_loop["currency"] == "EUR"
     assert stub_loop["country"] == "Germany"
@@ -124,7 +124,7 @@ def test_cli_telegram_happy_path(stub_loop, wantlist_file):
         ],
     )
     assert result.exit_code == 0, result.output
-    assert stub_loop["alerter_type"] == da_alert.AlerterType.TELEGRAM
+    assert stub_loop["alerter_type"] == "TELEGRAM"
     assert stub_loop["alerter_kwargs"] == {"telegram_token": "TG", "telegram_chat_id": "42"}
 
 


### PR DESCRIPTION
## What
Built-ins (Pushbullet, Telegram) work unchanged. Plugin packages can register themselves via the \`discogs_alert.alerters\` entry-point group:

\`\`\`toml
[project.entry-points."discogs_alert.alerters"]
ntfy = "discogs_alert_ntfy:NtfyAlerter"
\`\`\`

After \`pip install discogs-alert-ntfy\`, \`--alerter-type=NTFY\` is selectable. No core fork needed.

## Changes
- New \`discover_alerters()\` / \`alerter_names()\`. \`get_alerter()\` accepts both string names and \`AlerterType\` enum members (back-compat).
- Built-ins always win over plugins with the same name; broken plugins are logged and skipped.
- CLI \`--alerter-type\` is now \`click.Choice(alerter_names())\` — plugin alerters show up in \`--help\` automatically. Plugin alerters get an empty kwargs dict and read their own config.
- pyproject registers the built-ins under \`[tool.poetry.plugins."discogs_alert.alerters"]\` so installed copies expose them via entry points.
- README updated with a "plugin authors" walkthrough.

## Tests
9 new tests on the registry: entry-point discovery, built-in protection, broken-plugin tolerance, non-Alerter rejection, case-insensitivity, enum back-compat. 157 tests passing.