### PR TITLE
Sharper alerter failure logs (Retry-After, dead-auth detection)

### DIFF
--- a/discogs_alert/alert/_response.py
+++ b/discogs_alert/alert/_response.py
@@ -1,0 +1,79 @@
+"""Shared HTTP-response handling for alerters.
+
+Different alerter providers respond with different error shapes, but the
+*meaning* of those shapes is broadly consistent:
+
+- 2xx → success.
+- 401 / 403 / 410 → authentication is dead (revoked token, dormant account,
+  service-side ban). Retrying won't help; logging at ERROR is the right level.
+- 429 → rate limited. The provider may include a `Retry-After` header. We log
+  the requested cool-off so the user can diagnose noisy logs.
+- Anything else → transient failure; the loop's natural cadence retries.
+
+In all non-2xx cases the alerter returns False so the listing isn't
+mark-as-seen'd; next loop iteration retries (assuming the issue clears).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Mapping
+
+logger = logging.getLogger(__name__)
+
+# Status codes that mean "your auth is dead, don't bother trying again until
+# the user does something" — log loudly so the cause is obvious.
+_DEAD_AUTH_STATUSES = (401, 403, 410)
+
+
+def parse_retry_after_seconds(headers: Mapping[str, Any]) -> float | None:
+    """Parse a `Retry-After` HTTP header value into seconds.
+
+    The header can be either a number-of-seconds (integer or float) or an
+    HTTP-date. We only handle the seconds form — the date form is rare in
+    practice for the alerters we talk to, and would require dragging in a
+    parser. Returns None for missing or unparseable values.
+    """
+
+    raw = headers.get("Retry-After") if hasattr(headers, "get") else None
+    if raw is None:
+        return None
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+def log_alerter_failure(
+    provider: str,
+    status_code: int,
+    body: bytes | str,
+    headers: Mapping[str, Any] | None = None,
+) -> None:
+    """Log an alerter HTTP failure at the right level for the response shape.
+
+    Authentication-dead (401/403/410) → ERROR with a hint. Rate-limited (429)
+    → WARNING with the parsed Retry-After (if present). Other non-2xx →
+    ERROR.
+    """
+
+    body_preview = body[:200] if isinstance(body, (bytes, str)) else repr(body)[:200]
+    if status_code in _DEAD_AUTH_STATUSES:
+        logger.error(
+            "%s notification failed (HTTP %s — auth dead, retrying won't help): %s",
+            provider,
+            status_code,
+            body_preview,
+        )
+        return
+    if status_code == 429:
+        retry_after = parse_retry_after_seconds(headers or {})
+        retry_msg = f" — Retry-After: {retry_after}s" if retry_after is not None else ""
+        logger.warning(
+            "%s notification rate-limited (HTTP 429%s): %s",
+            provider,
+            retry_msg,
+            body_preview,
+        )
+        return
+    logger.error("%s notification failed (HTTP %s): %s", provider, status_code, body_preview)

--- a/discogs_alert/alert/pushbullet.py
+++ b/discogs_alert/alert/pushbullet.py
@@ -11,6 +11,7 @@ import logging
 
 import requests
 
+from discogs_alert.alert._response import log_alerter_failure
 from discogs_alert.alert.base import Alerter
 
 logger = logging.getLogger(__name__)
@@ -34,6 +35,6 @@ class PushbulletAlerter(Alerter):
             logger.error("Exception sending pushbullet push", exc_info=True)
             return False
         if resp.status_code != 200:
-            logger.error("error %s sending pushbullet notification: %s", resp.status_code, resp.content[:200])
+            log_alerter_failure("Pushbullet", resp.status_code, resp.content, resp.headers)
             return False
         return True

--- a/discogs_alert/alert/telegram.py
+++ b/discogs_alert/alert/telegram.py
@@ -6,6 +6,7 @@ import logging
 
 import requests
 
+from discogs_alert.alert._response import log_alerter_failure
 from discogs_alert.alert.base import Alerter
 
 logger = logging.getLogger(__name__)
@@ -33,6 +34,6 @@ class TelegramAlerter(Alerter):
             logger.error("Exception sending telegram message", exc_info=True)
             return False
         if resp.status_code != 200:
-            logger.error("error %s sending telegram notification: %s", resp.status_code, resp.text[:200])
+            log_alerter_failure("Telegram", resp.status_code, resp.text, resp.headers)
             return False
         return True

--- a/tests/notify/test_alert_response.py
+++ b/tests/notify/test_alert_response.py
@@ -1,0 +1,87 @@
+"""Tests for the shared HTTP-response helper used by alerters."""
+
+import logging
+
+import pytest
+
+from discogs_alert.alert._response import log_alerter_failure, parse_retry_after_seconds
+
+# -- parse_retry_after_seconds --------------------------------------------
+
+
+def test_parse_retry_after_handles_seconds_int():
+    assert parse_retry_after_seconds({"Retry-After": "30"}) == 30.0
+
+
+def test_parse_retry_after_handles_seconds_float():
+    assert parse_retry_after_seconds({"Retry-After": "30.5"}) == 30.5
+
+
+def test_parse_retry_after_returns_none_for_missing_header():
+    assert parse_retry_after_seconds({}) is None
+
+
+def test_parse_retry_after_returns_none_for_unparseable_value():
+    """We don't bother with HTTP-date form; unsupported = None, not exception."""
+
+    assert parse_retry_after_seconds({"Retry-After": "Wed, 21 Oct 2026 07:28:00 GMT"}) is None
+    assert parse_retry_after_seconds({"Retry-After": ""}) is None
+
+
+def test_parse_retry_after_handles_non_string_input():
+    """A `Mapping` without `.get` shouldn't blow up."""
+
+    class NoGet:
+        pass
+
+    assert parse_retry_after_seconds(NoGet()) is None
+
+
+# -- log_alerter_failure ---------------------------------------------------
+
+
+def test_dead_auth_logs_at_error(caplog: pytest.LogCaptureFixture):
+    with caplog.at_level(logging.ERROR, logger="discogs_alert.alert._response"):
+        log_alerter_failure("Pushbullet", 401, b'{"error":"dead account"}', {})
+    rec = caplog.records[-1]
+    assert rec.levelno == logging.ERROR
+    assert "auth dead" in rec.getMessage()
+
+
+@pytest.mark.parametrize("status", [401, 403, 410])
+def test_all_dead_auth_statuses_log_at_error(status, caplog: pytest.LogCaptureFixture):
+    with caplog.at_level(logging.ERROR, logger="discogs_alert.alert._response"):
+        log_alerter_failure("Telegram", status, "x", {})
+    assert caplog.records[-1].levelno == logging.ERROR
+
+
+def test_429_logs_at_warning_with_retry_after(caplog: pytest.LogCaptureFixture):
+    with caplog.at_level(logging.WARNING, logger="discogs_alert.alert._response"):
+        log_alerter_failure("Pushbullet", 429, b"slow down", {"Retry-After": "120"})
+    rec = caplog.records[-1]
+    assert rec.levelno == logging.WARNING
+    assert "rate-limited" in rec.getMessage()
+    assert "120" in rec.getMessage()
+
+
+def test_429_without_retry_after_still_logs_warning(caplog: pytest.LogCaptureFixture):
+    with caplog.at_level(logging.WARNING, logger="discogs_alert.alert._response"):
+        log_alerter_failure("Pushbullet", 429, b"slow", {})
+    assert caplog.records[-1].levelno == logging.WARNING
+
+
+def test_other_5xx_logs_at_error(caplog: pytest.LogCaptureFixture):
+    with caplog.at_level(logging.ERROR, logger="discogs_alert.alert._response"):
+        log_alerter_failure("Pushbullet", 503, b"ouch", {})
+    rec = caplog.records[-1]
+    assert rec.levelno == logging.ERROR
+    assert "503" in rec.getMessage()
+
+
+def test_body_is_truncated_to_200_chars(caplog: pytest.LogCaptureFixture):
+    long = b"x" * 1000
+    with caplog.at_level(logging.ERROR, logger="discogs_alert.alert._response"):
+        log_alerter_failure("Pushbullet", 500, long, {})
+    msg = caplog.records[-1].getMessage()
+    # Should contain at most 200 'x's
+    assert "x" * 201 not in msg


### PR DESCRIPTION
## Why
\`send_alert\` logged "error N sending notification" at ERROR for every non-2xx, which buried two distinct signals:

1. **401/403/410** = auth is dead (revoked token, dormant Pushbullet account, banned bot). Retrying won't help.
2. **429** = rate-limited; \`Retry-After\` says how long to wait. Should be WARNING, not ERROR.

Specifically motivated by smoke-testing against the user's dormant Pushbullet account, which 401s with "Account has not been used for over a month" — buried under a generic ERROR.

## Change
- New \`alert/_response.py\` with \`parse_retry_after_seconds\` and \`log_alerter_failure\` helpers.
- Pushbullet/Telegram alerters use them instead of inline \`logger.error\`.
- 12 new tests on the helper.