### PR TITLE
Drop deprecated ruff  option

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,6 @@ target-version = "py310"
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "TID", "W"]
-ignore-init-module-imports = true
 
 [tool.ruff.lint.flake8-tidy-imports]
 ban-relative-imports = "all"


### PR DESCRIPTION
Tiny: silences the deprecation warning that fires on every ruff run. Verified no `__init__.py` has unused imports.