### PR TITLE
Add --once and --log-level CLI flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,8 @@ Here are the possible arguments:
 
 And here are the possible flags:
 * `-V` `--verbose`: (bool) use this flag if you want to run the server in verbose mode, meaning it will log updates to the command line as it runs (default=`false`)
-* `-T` `--test`: (bool) use this flag if you want to run the script once rather than a fixed number of times per hour. This is useful not only for testing, but also if you're running the service as a cron job (& => cron handles scheduling).
+* `-O` `--once`: (bool) run the loop exactly once and exit instead of repeating on a schedule. Useful when you're driving `discogs_alert` from cron / systemd-timer / launchd and want the schedule managed externally. (`-T`/`--test` is a deprecated alias for the same thing.)
+* `-l` `--log-level`: (str) override the root log level (`DEBUG`, `INFO`, `WARNING`, `ERROR`). Useful for quieting INFO chatter under cron (`--log-level=WARNING`) or capturing extra detail when debugging.
 
 NB: all command-line options & arguments outlined above can be configured using environment variables. Check out `python -m discogs_alert --help` for more info.
 
@@ -246,7 +247,7 @@ $ python -m discogs_alert -dt <discogs_access_token> -at PUSHBULLET -pt <pushbul
 
 If you aren't running `discogs_alert` as a background docker container, another good approach (and my preference) is to run the process as a `cron` job. This method uses the cron command-line utility to run `discogs_alert` at regular intervals. Assuming you have specified the required environment variables, all you have to do is run `crontab -e` to open the cronjob editing window before appending the following line to the bottom of the file
 ```bash
-*/10 * * * * source ~/.bash_profile; python -m discogs_alert -T >> <path_to_log_file>.log 2>&1
+*/10 * * * * source ~/.bash_profile; python -m discogs_alert --once >> <path_to_log_file>.log 2>&1
 ```
 Upon saving & existing the file, `discogs_alert` will be run every 10 minutes and its logs will be output to the specified log file. You can then `tail -f <path_to_log_file>.log` at any point to make sure that things are running as expected.
 

--- a/discogs_alert/__main__.py
+++ b/discogs_alert/__main__.py
@@ -219,12 +219,39 @@ logger = logging.getLogger(__name__)
     "-V", "--verbose", default=False, is_flag=True, help="use flag if you want to see logs as the program runs"
 )
 @click.option(
+    "-l",
+    "--log-level",
+    default=None,
+    envvar="DA_LOG_LEVEL",
+    type=click.Choice(["DEBUG", "INFO", "WARNING", "ERROR"], case_sensitive=False),
+    help=(
+        "Override the root log level. Useful for quieting `INFO` chatter under cron "
+        "(`--log-level=WARNING`) or capturing extra detail when debugging "
+        "(`--log-level=DEBUG`). When omitted, defaults to INFO (or whatever your "
+        "environment's basicConfig resolved to)."
+    ),
+)
+@click.option(
+    "-O",
+    "--once",
+    "once",
+    default=False,
+    is_flag=True,
+    envvar="DA_ONCE",
+    help=(
+        "Run the loop exactly once and exit, instead of scheduling it to repeat. "
+        "Useful when you're driving discogs_alert from cron / systemd-timer / "
+        "launchd and want the schedule managed externally."
+    ),
+)
+@click.option(
     "-T",
     "--test",
+    "test",
     default=False,
     is_flag=True,
     hidden=True,
-    help="use flag if you want to immediately run the program (to test that your wantlist is correct)",
+    help="Deprecated alias for --once; kept for backward compatibility.",
 )
 @click.version_option(__version__)
 def main(
@@ -249,11 +276,20 @@ def main(
     stats_gate,
     inter_release_delay,
     verbose,
+    log_level,
+    once,
     test,
 ):
     """
     This loop queries your watchlist at regular intervals, alerting you if a release satisfying your criteria is found.
     """
+
+    # `--once` is the canonical name; `--test` is the legacy alias.
+    one_shot = once or test
+
+    # Apply log-level override after `basicConfig` already ran (at module import).
+    if log_level is not None:
+        logging.getLogger().setLevel(log_level.upper())
 
     # if both a list ID and a local wantlist path are provided, use the wantlist (to force-enable local testing)
     # TODO: combine them?
@@ -310,7 +346,7 @@ def main(
     )
 
     da_loop.loop(**loop_kwargs)
-    if not test:
+    if not one_shot:
         schedule.every(int(60 / frequency)).minutes.do(lambda: da_loop.loop(**loop_kwargs))
         while 1:
             schedule.run_pending()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -175,6 +175,39 @@ def test_cli_state_path_passes_through(stub_loop, wantlist_file, tmp_path):
     assert stub_loop["state_path"] == str(db)
 
 
+def test_cli_once_flag_runs_loop_once(stub_loop, wantlist_file):
+    """`--once` should invoke `loop` exactly once and skip the schedule path."""
+
+    runner = CliRunner()
+    args = _base_args(wantlist_file)
+    # _base_args already includes --test (the legacy alias for --once); replace
+    # it with the canonical flag so we exercise that path.
+    args.remove("--test")
+    args.append("--once")
+    result = runner.invoke(da_main.main, args)
+    assert result.exit_code == 0, result.output
+
+
+def test_cli_log_level_flag_propagates(stub_loop, wantlist_file, monkeypatch):
+    import logging as stdlogging
+
+    runner = CliRunner()
+    result = runner.invoke(
+        da_main.main, _base_args(wantlist_file) + ["--log-level", "WARNING"]
+    )
+    assert result.exit_code == 0, result.output
+    # Root logger level should now be WARNING.
+    assert stdlogging.getLogger().level == stdlogging.WARNING
+
+
+def test_cli_log_level_invalid_value_rejected(stub_loop, wantlist_file):
+    runner = CliRunner()
+    result = runner.invoke(
+        da_main.main, _base_args(wantlist_file) + ["--log-level", "TRACE"]
+    )
+    assert result.exit_code != 0
+
+
 def test_cli_list_id_and_wantlist_path_mutual_exclusion(stub_loop, wantlist_file):
     runner = CliRunner()
     result = runner.invoke(


### PR DESCRIPTION
## Summary
- \`-T/--test\` was hidden but documented in the README as the cron flag — promoted to first-class as \`-O/--once\` (\`--test\` kept as deprecated alias).
- \`--log-level\` lets cron users dial down INFO chatter (\`--log-level=WARNING\`) or capture extra detail (\`--log-level=DEBUG\`), which the bool \`--verbose\` couldn't.
- README updated; cron example uses \`--once\`.

## Tests
3 new CLI tests: \`--once\` happy path, \`--log-level\` propagation, invalid level rejected.