### PR TITLE
AlertStore stats helper + verbose log on loop start

### DIFF
--- a/discogs_alert/loop.py
+++ b/discogs_alert/loop.py
@@ -203,6 +203,12 @@ def loop(
         alerter = get_alerter(alerter_type, alerter_kwargs)
 
         with da_state.AlertStore(state_path) as store:
+            if verbose:
+                s = store.stats()
+                logger.info(
+                    "alert store at %s: %d total (last 24h: %d, last 7d: %d)",
+                    store.path, s["total"], s["last_24h"], s["last_7d"],
+                )
             wantlist_items = load_wantlist(list_id, user_token_client, wantlist_path)
             random.shuffle(wantlist_items)
             num_items = len(wantlist_items)

--- a/discogs_alert/state.py
+++ b/discogs_alert/state.py
@@ -88,6 +88,33 @@ class AlertStore:
         cur = self._conn.execute("SELECT COUNT(*) FROM sent_alerts")
         return int(cur.fetchone()[0])
 
+    def stats(self) -> dict[str, int]:
+        """Return a dict of total / last-24h / last-7d alert counts.
+
+        Used by `loop.loop` at startup (in verbose mode) so the operator can see
+        at-a-glance whether the dedup store is actually firing — a sudden jump in
+        last-24h while the upstream listings haven't changed usually means either
+        the SQLite DB was wiped or `--state-path` is pointing somewhere new.
+        """
+
+        # SUM(CASE WHEN ...) over COUNT(*) FILTER so this works on the older
+        # SQLite versions that ship with some Linux distros (FILTER needs 3.30+).
+        cur = self._conn.execute(
+            """
+            SELECT
+                COUNT(*),
+                SUM(CASE WHEN sent_at >= datetime('now', '-1 day')  THEN 1 ELSE 0 END),
+                SUM(CASE WHEN sent_at >= datetime('now', '-7 days') THEN 1 ELSE 0 END)
+            FROM sent_alerts
+            """
+        )
+        total, last_24h, last_7d = cur.fetchone()
+        return {
+            "total": int(total or 0),
+            "last_24h": int(last_24h or 0),
+            "last_7d": int(last_7d or 0),
+        }
+
     def prune_older_than(self, days: int) -> int:
         """Delete alert records older than `days` days. Returns the number of rows
         deleted.

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -110,6 +110,39 @@ def test_concurrent_inserts_within_one_window_dedup(tmp_store: da_state.AlertSto
     assert tmp_store.count() == 1
 
 
+def test_stats_empty_store(tmp_store: da_state.AlertStore):
+    assert tmp_store.stats() == {"total": 0, "last_24h": 0, "last_7d": 0}
+
+
+def test_stats_counts_recent_rows(tmp_store: da_state.AlertStore):
+    tmp_store.mark_seen(1, 10, "t", "b")
+    tmp_store.mark_seen(2, 10, "t", "b")
+    tmp_store.mark_seen(3, 11, "t", "b")
+    s = tmp_store.stats()
+    assert s == {"total": 3, "last_24h": 3, "last_7d": 3}
+
+
+def test_stats_time_windows(tmp_path: Path):
+    db_path = tmp_path / "state.db"
+    with da_state.AlertStore(db_path) as store:
+        # Three rows at distinct ages: now, 3 days ago, 30 days ago.
+        store._conn.executemany(  # noqa: SLF001 — direct write keeps the test deterministic
+            "INSERT INTO sent_alerts (listing_id, release_id, title, body, sent_at) "
+            "VALUES (?, ?, ?, ?, datetime('now', ?))",
+            [
+                (1, 1, "t", "b", "-1 minute"),
+                (2, 1, "t", "b", "-3 days"),
+                (3, 1, "t", "b", "-30 days"),
+            ],
+        )
+        store._conn.commit()
+
+        s = store.stats()
+        assert s["total"] == 3
+        assert s["last_24h"] == 1
+        assert s["last_7d"] == 2
+
+
 def test_sent_at_is_iso_like(tmp_store: da_state.AlertStore):
     """Sanity-check: the default `sent_at` should be parseable as a YYYY-MM-DD HH:MM:SS string."""
 


### PR DESCRIPTION
## Summary
- Adds `AlertStore.stats()` returning `{total, last_24h, last_7d}` via a single portable `SUM(CASE WHEN …)` query.
- `loop.loop` logs the stats at startup in verbose mode so a wiped `state.db` or a misconfigured `--state-path` is obvious from logs.

## Test plan
- [x] `pytest tests/test_state.py` (16 passed, includes new empty/populated/time-window cases)
- [x] Full suite: 204 passed, coverage 89.76% (above the 88% gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)