### PR TITLE
Auto-prune AlertStore rows older than --prune-after-days

### DIFF
--- a/discogs_alert/__main__.py
+++ b/discogs_alert/__main__.py
@@ -247,6 +247,18 @@ logger = logging.getLogger(__name__)
     ),
 )
 @click.option(
+    "--prune-after-days",
+    default=90,
+    show_default=True,
+    type=click.IntRange(min=0),
+    envvar="DA_PRUNE_AFTER_DAYS",
+    help=(
+        "On startup, drop dedup records older than this many days from the local "
+        "state database. Listings disappear from Discogs long before this, so "
+        "older rows can't ever match a future listing. Set to 0 to disable."
+    ),
+)
+@click.option(
     "-V", "--verbose", default=False, is_flag=True, help="use flag if you want to see logs as the program runs"
 )
 @click.option(
@@ -309,6 +321,7 @@ def main(
     state_path,
     stats_gate,
     inter_release_delay,
+    prune_after_days,
     verbose,
     log_level,
     once,
@@ -369,6 +382,7 @@ def main(
         state_path=state_path,
         use_stats_gate=stats_gate,
         inter_release_delay_seconds=inter_release_delay,
+        prune_after_days=prune_after_days,
         verbose=verbose,
     )
 

--- a/discogs_alert/loop.py
+++ b/discogs_alert/loop.py
@@ -172,6 +172,7 @@ def loop(
     state_path: Optional[Path] = None,
     use_stats_gate: bool = True,
     inter_release_delay_seconds: float = 0.0,
+    prune_after_days: int = 90,
     verbose: bool = False,
 ):
     """Event loop. One iteration: pull the wantlist, query the marketplace for each
@@ -203,6 +204,13 @@ def loop(
         alerter = get_alerter(alerter_type, alerter_kwargs)
 
         with da_state.AlertStore(state_path) as store:
+            if prune_after_days > 0:
+                pruned = store.prune_older_than(prune_after_days)
+                if pruned and verbose:
+                    logger.info(
+                        "pruned %d alert record(s) older than %d days from %s",
+                        pruned, prune_after_days, store.path,
+                    )
             if verbose:
                 s = store.stats()
                 logger.info(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -244,6 +244,20 @@ def test_cli_log_level_invalid_value_rejected(stub_loop, wantlist_file):
     assert result.exit_code != 0
 
 
+def test_cli_prune_after_days_default(stub_loop, wantlist_file):
+    runner = CliRunner()
+    result = runner.invoke(da_main.main, _base_args(wantlist_file))
+    assert result.exit_code == 0, result.output
+    assert stub_loop["prune_after_days"] == 90
+
+
+def test_cli_prune_after_days_override(stub_loop, wantlist_file):
+    runner = CliRunner()
+    result = runner.invoke(da_main.main, _base_args(wantlist_file) + ["--prune-after-days", "0"])
+    assert result.exit_code == 0, result.output
+    assert stub_loop["prune_after_days"] == 0
+
+
 def test_cli_list_id_and_wantlist_path_mutual_exclusion(stub_loop, wantlist_file):
     runner = CliRunner()
     result = runner.invoke(


### PR DESCRIPTION
## Summary
- `AlertStore.prune_older_than` was unused outside tests — the dedup db grew forever.
- New `--prune-after-days` (default 90, env `DA_PRUNE_AFTER_DAYS`, 0 to disable) calls it once on loop startup.
- Discogs listings disappear long before 90 days, so older rows can never match a future listing.

**Stacked on #114** — base is \`feat/alertstore-stats\`. Retarget to \`main\` once #114 is merged.

## Test plan
- [x] Full suite green: 206 passed, coverage 89.71% (above 88% gate)
- [x] New CLI tests cover default + override

🤖 Generated with [Claude Code](https://claude.com/claude-code)