### PR TITLE
Fall back to stale currency cache when Frankfurter is unreachable

### DIFF
--- a/discogs_alert/util/currency.py
+++ b/discogs_alert/util/currency.py
@@ -53,6 +53,24 @@ def _disk_cache_path(base_currency: str) -> pathlib.Path:
     return CACHE_DIR / f"{now.year}-{now.week}-{base_currency}.json"
 
 
+def _newest_stale_cache(base_currency: str) -> pathlib.Path | None:
+    """Return the most recent on-disk cache for `base_currency`, regardless of week.
+
+    Used as a fallback when Frankfurter is unreachable and we don't have a
+    current-week cache: rates change slowly enough (cents on the dollar) that
+    last week's rates are far better than crashing the loop.
+    """
+
+    if not CACHE_DIR.exists():
+        return None
+    candidates = sorted(
+        CACHE_DIR.glob(f"*-{base_currency}.json"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    return candidates[0] if candidates else None
+
+
 @time_cache(seconds=3600)
 def get_currency_rates(base_currency: str) -> CurrencyRates:
     """Fetch live currency exchange rates from Frankfurter.
@@ -92,18 +110,29 @@ def get_currency_rates(base_currency: str) -> CurrencyRates:
         response = requests.get(
             f"{FRANKFURTER_BASE_URL}/latest", params={"base": base_currency}, timeout=HTTP_TIMEOUT_SECONDS
         )
-    except requests.RequestException as exc:
-        raise CurrencyProviderError(f"Failed to reach Frankfurter for base {base_currency}: {exc}") from exc
-
-    if response.status_code != 200:
+        response.raise_for_status()
+        payload = response.json()
+        rates = payload.get("rates")
+        if not isinstance(rates, dict):
+            raise CurrencyProviderError(f"Frankfurter response missing 'rates': {payload!r}")
+    except (requests.RequestException, ValueError, CurrencyProviderError) as exc:
+        # Upstream is unreachable / errored / returned junk. Fall back to the
+        # newest stale cache for this base currency if we have one — rates only
+        # drift slowly, and a stale conversion is far better than crashing the
+        # loop. Only re-raise if we have no cache to fall back to.
+        stale = _newest_stale_cache(base_currency)
+        if stale is not None:
+            try:
+                logger.warning(
+                    "Frankfurter unreachable (%s); falling back to stale cache %s",
+                    exc, stale,
+                )
+                return json.load(stale.open("r"))
+            except (json.JSONDecodeError, OSError):
+                logger.warning("Stale cache %s unreadable", stale, exc_info=True)
         raise CurrencyProviderError(
-            f"Frankfurter returned {response.status_code} for base {base_currency}: {response.text[:200]}"
-        )
-
-    payload = response.json()
-    rates = payload.get("rates")
-    if not isinstance(rates, dict):
-        raise CurrencyProviderError(f"Frankfurter response missing 'rates': {payload!r}")
+            f"Failed to reach Frankfurter for base {base_currency} and no usable cache: {exc}"
+        ) from exc
 
     # Frankfurter omits the base currency from `rates`; include it so callers
     # may safely look it up.

--- a/tests/util/test_currency.py
+++ b/tests/util/test_currency.py
@@ -122,6 +122,60 @@ def test_get_currency_rates_raises_on_malformed_payload(monkeypatch: pytest.Monk
         da_currency.get_currency_rates("EUR")
 
 
+def test_falls_back_to_stale_cache_on_network_error(monkeypatch: pytest.MonkeyPatch):
+    """When Frankfurter is unreachable, a previously-written cache (any age)
+    must be returned instead of raising — the loop should keep working through
+    short upstream outages.
+    """
+
+    # Seed an old-week cache file directly under CACHE_DIR.
+    da_currency.CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    stale = da_currency.CACHE_DIR / "1999-1-EUR.json"
+    json.dump({"USD": 1.05, "EUR": 1.0}, stale.open("w"))
+
+    monkeypatch.setattr(requests, "get", _fake_response(raise_exc=requests.ConnectionError("nope")))
+    rates = da_currency.get_currency_rates("EUR")
+    assert rates == {"USD": 1.05, "EUR": 1.0}
+
+
+def test_falls_back_to_stale_cache_on_5xx(monkeypatch: pytest.MonkeyPatch):
+    da_currency.CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    stale = da_currency.CACHE_DIR / "1999-1-EUR.json"
+    json.dump({"USD": 1.07, "EUR": 1.0}, stale.open("w"))
+
+    monkeypatch.setattr(requests, "get", _fake_response(503, {"error": "down"}))
+    rates = da_currency.get_currency_rates("EUR")
+    assert rates == {"USD": 1.07, "EUR": 1.0}
+
+
+def test_stale_cache_fallback_picks_newest(monkeypatch: pytest.MonkeyPatch, tmp_path):
+    """If multiple stale caches exist, the most recently modified one wins."""
+
+    import os
+    da_currency.CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    older = da_currency.CACHE_DIR / "1999-1-EUR.json"
+    newer = da_currency.CACHE_DIR / "1999-2-EUR.json"
+    json.dump({"USD": 1.0}, older.open("w"))
+    json.dump({"USD": 2.0}, newer.open("w"))
+    # Force `older` to look older than `newer`.
+    os.utime(older, (1, 1))
+    os.utime(newer, (1000, 1000))
+
+    monkeypatch.setattr(requests, "get", _fake_response(raise_exc=requests.ConnectionError("nope")))
+    rates = da_currency.get_currency_rates("EUR")
+    assert rates == {"USD": 2.0}
+
+
+def test_no_stale_cache_means_we_still_raise(monkeypatch: pytest.MonkeyPatch):
+    """Without any cache to fall back to, network failures must still surface
+    as `CurrencyProviderError` so the loop's exception logging fires.
+    """
+
+    monkeypatch.setattr(requests, "get", _fake_response(raise_exc=requests.ConnectionError("nope")))
+    with pytest.raises(da_currency.CurrencyProviderError):
+        da_currency.get_currency_rates("EUR")
+
+
 def test_convert_currency_uses_rates(mock_currency_rates, rates: da_currency.CurrencyRates):
     assert da_currency.convert_currency(1, "GBP", "EUR") == 1 / rates["GBP"]
     assert da_currency.convert_currency(1, "CHF", "EUR") == 1 / rates["CHF"]


### PR DESCRIPTION
## Summary
- If Frankfurter is unreachable (network error, 5xx, malformed JSON) AND there's no current-week cache, fall back to the newest stale cache for the same base currency rather than crashing the loop.
- Rates drift slowly enough that last week's are far better than \`CurrencyProviderError\` propagating through every iteration.
- Still raises if there's no cache at all.

## Test plan
- [x] Full suite: 205 passed, coverage 89.81% (above 88%)
- [x] New tests cover network/5xx fallback, newest-cache wins, no-cache still raises

🤖 Generated with [Claude Code](https://claude.com/claude-code)