### PR TITLE
Drop unused Client.get_wantlist

### DIFF
--- a/discogs_alert/client.py
+++ b/discogs_alert/client.py
@@ -87,11 +87,6 @@ class Client:
             return False
         return da_entities.ReleaseStats.model_validate(release_stats_dict)
 
-    def get_wantlist(self, username: str):
-        # TODO: add entities to deserialise this correctly
-        url = f"{self._base_url}/users/{username}/wants"
-        return self._get(url)
-
 
 class UserTokenClient(Client):
     """A client for sending requests with a user token (for non-oauth authentication).


### PR DESCRIPTION
## Summary
- \`Client.get_wantlist\` has had no callers in this project for a long time and a stale TODO that was never addressed.
- Wantlist loading goes through \`get_list(list_id)\` or a local JSON; the /wants endpoint helper is dead code.

## Test plan
- [x] No callers (\`grep get_wantlist\` clean)
- [x] Suite green: 201 passed, coverage 90.10%

🤖 Generated with [Claude Code](https://claude.com/claude-code)