### PR TITLE
README: document --inter-release-delay and --stats-gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,8 +228,10 @@ Here are the possible arguments:
 * `-tt` `--telegram-token`: (str) your telegram API token (only required if `"--alerter-type=TELEGRAM"`)
 * `-tci` `--telegram-chat-id`: (str) your telgram chat ID (only required if `"--alerter-type=TELEGRAM"`)
 * `-sp` `--state-path`: (str) path to the local SQLite database used to deduplicate alerts (default=`~/.discogs_alert/state.db`).
+* `-d` `--inter-release-delay`: (float) seconds to sleep (with ±25% jitter) between marketplace scrapes within a single iteration. Useful for very large wantlists where Cloudflare may throttle a tight burst. Default `0` (no delay).
 
 And here are the possible flags:
+* `--stats-gate` / `--no-stats-gate`: (bool) use the cheap `/marketplace/stats` API to skip the expensive marketplace scrape for releases with no listings or above your price threshold (default `--stats-gate`). Disable only for debugging.
 * `-V` `--verbose`: (bool) use this flag if you want to run the server in verbose mode, meaning it will log updates to the command line as it runs (default=`false`)
 * `-T` `--test`: (bool) use this flag if you want to run the script once rather than a fixed number of times per hour. This is useful not only for testing, but also if you're running the service as a cron job (& => cron handles scheduling).
 


### PR DESCRIPTION
## Summary
- Adds entries for \`-d/--inter-release-delay\` and \`--stats-gate/--no-stats-gate\` to the options/flags listing — both were shipped in earlier PRs but never documented in the README.

## Test plan
- [x] No code changes; doc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)