### PR TITLE
Move tox from runtime to dev-dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ curl_cffi = "^0.7"
 pydantic = "^2.6"
 requests = "^2.32"
 schedule = "^1.2"
-tox = "^4.15"
 
 [tool.poetry.dev-dependencies]
 pre-commit = "^3.7"
@@ -26,6 +25,7 @@ pytest = "^8.2"
 pytest-cov = "^5.0"
 pytest-sugar = "^1.0"
 ruff = "^0.6"
+tox = "^4.15"
 
 [build-system]
 requires = ["poetry-core>=1.9.0"]


### PR DESCRIPTION
## Summary
- \`tox\` is a test/CI tool, never imported by the package at runtime.
- Keeping it under \`[tool.poetry.dependencies]\` meant \`pip install discogs-alert\` pulled tox + virtualenv + filelock + platformdirs onto end users' machines for no reason.

## Test plan
- [x] No code changes; \`grep -r 'import tox' discogs_alert/\` is empty.
- [x] CI's \`tox\` invocation still uses the dev-dep group, so the test workflow is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)