### PR TITLE
Move logging.basicConfig out of module import

### DIFF
--- a/discogs_alert/__main__.py
+++ b/discogs_alert/__main__.py
@@ -7,7 +7,6 @@ import schedule
 from discogs_alert import __version__, alert as da_alert, entities as da_entities, loop as da_loop
 from discogs_alert.util import click as da_click, constants as dac
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
@@ -318,10 +317,14 @@ def main(
     This loop queries your watchlist at regular intervals, alerting you if a release satisfying your criteria is found.
     """
 
+    # Configure logging here, not at module import — importing the package
+    # shouldn't install a global handler on the root logger.
+    logging.basicConfig(level=logging.INFO)
+
     # `--once` is the canonical name; `--test` is the legacy alias.
     one_shot = once or test
 
-    # Apply log-level override after `basicConfig` already ran (at module import).
+    # Apply log-level override on top of the basicConfig above.
     if log_level is not None:
         logging.getLogger().setLevel(log_level.upper())
 


### PR DESCRIPTION
## Summary
- Configuring the root logger at module-import time pollutes any consumer of \`discogs_alert\` (plugin alerter packages, tests with their own logging setup, future library usage).
- Move it inside \`main()\` so only the CLI entry point installs a handler.

## Test plan
- [x] Suite green: 201 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)