### PR TITLE
Add ntfy.sh built-in alerter

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,16 @@ The possible optional filters are as follows:
 
 You can choose from  several different alerting services to notify you once a record you are searching is on sale, each coming with its own setup requirements. The options and their setup are outlined here
 
+#### ntfy.sh (lowest-friction)
+
+[ntfy.sh](https://ntfy.sh/) is the easiest alerter to set up — no account, no token, no bot. Pick a random hard-to-guess topic name (anyone with the topic name can read your notifications) and subscribe to that topic from the [iOS](https://apps.apple.com/us/app/ntfy/id1625396347), [Android](https://play.google.com/store/apps/details?id=io.heckel.ntfy), [desktop](https://docs.ntfy.sh/subscribe/desktop/), or [web](https://ntfy.sh/app) app. Then run:
+
+```bash
+$ python -m discogs_alert --alerter-type=NTFY --ntfy-topic=<your-topic>
+```
+
+For privacy / reliability, you can self-host ntfy and pass `--ntfy-server=https://ntfy.example.com`. If your ntfy server requires auth, pass `--ntfy-token=<token>`.
+
 #### Pushbullet
 
 As of June 2023, Pushbullet is only available on Android or Desktop. To use Pushbullet, you first need to create an [account](https://www.pushbullet.com/) before installing the app anywhere you wish to receive notifications. Once you've created an account, navigate to your [settings](https://www.pushbullet.com/#settings) page and  create an access token. As before, save this token somewhere on your computer. You'll need to configure it either at the command-line or via an environment variable (see the [usage](#usage) section below).

--- a/discogs_alert/__main__.py
+++ b/discogs_alert/__main__.py
@@ -180,6 +180,37 @@ logger = logging.getLogger(__name__)
     help="chat ID for telegram bot notification service.",
 )
 @click.option(
+    "--ntfy-topic",
+    cls=da_click.RequiredIf,
+    required_if=lambda x: str(x.get("alerter_type", "")).upper() == "NTFY",
+    required_if_str="alerter_type=NTFY",
+    type=str,
+    envvar="DA_NTFY_TOPIC",
+    help=(
+        "ntfy.sh topic name (anything random and hard-to-guess works — anyone "
+        "with the topic name can read your notifications). Subscribe to the "
+        "same topic from the ntfy iOS / Android / desktop / web app."
+    ),
+)
+@click.option(
+    "--ntfy-server",
+    default="https://ntfy.sh",
+    show_default=True,
+    type=str,
+    envvar="DA_NTFY_SERVER",
+    help="ntfy server URL. Override to point at a self-hosted instance.",
+)
+@click.option(
+    "--ntfy-token",
+    default=None,
+    type=str,
+    envvar="DA_NTFY_TOKEN",
+    help=(
+        "Optional ntfy access token (only needed for self-hosted instances "
+        "with auth enabled, or paid ntfy.sh tiers)."
+    ),
+)
+@click.option(
     "-sp",
     "--state-path",
     default=None,
@@ -245,6 +276,9 @@ def main(
     pushbullet_token,
     telegram_token,
     telegram_chat_id,
+    ntfy_topic,
+    ntfy_server,
+    ntfy_token,
     state_path,
     stats_gate,
     inter_release_delay,
@@ -269,6 +303,12 @@ def main(
         alerter_kwargs = {"pushbullet_token": pushbullet_token}
     elif alerter_type == "TELEGRAM":
         alerter_kwargs = {"telegram_token": telegram_token, "telegram_chat_id": telegram_chat_id}
+    elif alerter_type == "NTFY":
+        alerter_kwargs = {
+            "ntfy_topic": ntfy_topic,
+            "ntfy_server": ntfy_server,
+            "ntfy_token": ntfy_token,
+        }
     else:
         # Plugin alerter — its constructor is responsible for its own config.
         alerter_kwargs = {}

--- a/discogs_alert/alert/__init__.py
+++ b/discogs_alert/alert/__init__.py
@@ -24,6 +24,7 @@ from importlib.metadata import entry_points, EntryPoints
 from typing import Any, Dict, List, Type, Union
 
 from discogs_alert.alert.base import Alerter
+from discogs_alert.alert.ntfy import NtfyAlerter
 from discogs_alert.alert.pushbullet import PushbulletAlerter
 from discogs_alert.alert.telegram import TelegramAlerter
 
@@ -33,6 +34,7 @@ ENTRY_POINT_GROUP = "discogs_alert.alerters"
 
 # Built-in alerters — always available, regardless of entry-point installation.
 _BUILTIN_ALERTERS: Dict[str, Type[Alerter]] = {
+    "NTFY": NtfyAlerter,
     "PUSHBULLET": PushbulletAlerter,
     "TELEGRAM": TelegramAlerter,
 }
@@ -49,6 +51,7 @@ class AlerterType(enum.IntEnum):
 
     PUSHBULLET = enum.auto()
     TELEGRAM = enum.auto()
+    NTFY = enum.auto()
 
 
 def _load_entry_point_alerters() -> Dict[str, Type[Alerter]]:

--- a/discogs_alert/alert/ntfy.py
+++ b/discogs_alert/alert/ntfy.py
@@ -1,0 +1,56 @@
+"""ntfy.sh alerter.
+
+Lowest-friction alerter we ship: no account, no token. The user picks a topic
+name (anything random and hard-to-guess works) and subscribes from the ntfy iOS /
+Android / desktop / web app. We POST plain HTTP to
+``https://ntfy.sh/<topic>`` with the message title in the ``Title`` header and
+the message body as the request body — that's the entire setup.
+
+For privacy / reliability, ntfy.sh is also self-hostable; pass
+``--ntfy-server=https://ntfy.example.com`` (or ``DA_NTFY_SERVER``) to point at
+a custom instance.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import requests
+
+from discogs_alert.alert._response import log_alerter_failure
+from discogs_alert.alert.base import Alerter
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_SERVER = "https://ntfy.sh"
+HTTP_TIMEOUT_SECONDS = 10
+
+
+class NtfyAlerter(Alerter):
+    def __init__(self, ntfy_topic: str, ntfy_server: str = DEFAULT_SERVER, ntfy_token: str | None = None):
+        if not ntfy_topic:
+            raise ValueError("ntfy_topic is required")
+        self.ntfy_topic = ntfy_topic
+        self.ntfy_server = ntfy_server.rstrip("/")
+        self.ntfy_token = ntfy_token
+
+    def send_alert(self, message_title: str, message_body: str) -> bool:
+        url = f"{self.ntfy_server}/{self.ntfy_topic}"
+        # ntfy uses HTTP headers for metadata. Strip non-Latin-1 chars from the
+        # title — the spec requires Latin-1 in headers, and Discogs titles can
+        # contain things like "Deep²" that requests will reject.
+        safe_title = message_title.encode("ascii", "replace").decode("ascii")
+        headers = {"Title": safe_title}
+        if self.ntfy_token:
+            headers["Authorization"] = f"Bearer {self.ntfy_token}"
+        try:
+            resp = requests.post(
+                url, data=message_body.encode("utf-8"), headers=headers, timeout=HTTP_TIMEOUT_SECONDS
+            )
+        except requests.exceptions.RequestException:
+            logger.error("Exception sending ntfy push", exc_info=True)
+            return False
+        if resp.status_code >= 400:
+            log_alerter_failure("ntfy", resp.status_code, resp.content, resp.headers)
+            return False
+        return True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ build-backend = "poetry.core.masonry.api"
 #     [project.entry-points."discogs_alert.alerters"]
 #     ntfy = "discogs_alert_ntfy:NtfyAlerter"
 [tool.poetry.plugins."discogs_alert.alerters"]
+NTFY = "discogs_alert.alert.ntfy:NtfyAlerter"
 PUSHBULLET = "discogs_alert.alert.pushbullet:PushbulletAlerter"
 TELEGRAM = "discogs_alert.alert.telegram:TelegramAlerter"
 

--- a/tests/notify/test_ntfy.py
+++ b/tests/notify/test_ntfy.py
@@ -1,0 +1,89 @@
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+
+from discogs_alert.alert import ntfy as da_ntfy
+
+
+@pytest.fixture
+def alerter() -> da_ntfy.NtfyAlerter:
+    return da_ntfy.NtfyAlerter(ntfy_topic="my-topic")
+
+
+def _fake_post(status_code: int = 200, content: bytes = b"{}", raise_exc=None):
+    captured: dict = {}
+
+    def _post(url, data=None, headers=None, timeout=None):
+        captured["url"] = url
+        captured["data"] = data
+        captured["headers"] = headers
+        captured["timeout"] = timeout
+        if raise_exc is not None:
+            raise raise_exc
+        resp = MagicMock()
+        resp.status_code = status_code
+        resp.content = content
+        return resp
+
+    return _post, captured
+
+
+def test_send_alert_posts_to_topic(monkeypatch: pytest.MonkeyPatch, alerter):
+    post, captured = _fake_post(200)
+    monkeypatch.setattr(requests, "post", post)
+
+    assert alerter.send_alert("Hello", "World") is True
+
+    assert captured["url"] == "https://ntfy.sh/my-topic"
+    assert captured["headers"]["Title"] == "Hello"
+    assert "Authorization" not in captured["headers"]
+    assert captured["data"] == b"World"
+    assert captured["timeout"] == da_ntfy.HTTP_TIMEOUT_SECONDS
+
+
+def test_self_hosted_server_url(monkeypatch: pytest.MonkeyPatch):
+    """Custom servers should override the default and trim a trailing slash."""
+
+    alerter = da_ntfy.NtfyAlerter(ntfy_topic="t", ntfy_server="https://ntfy.example.com/")
+    post, captured = _fake_post(200)
+    monkeypatch.setattr(requests, "post", post)
+    alerter.send_alert("t", "b")
+    assert captured["url"] == "https://ntfy.example.com/t"
+
+
+def test_token_adds_auth_header(monkeypatch: pytest.MonkeyPatch):
+    alerter = da_ntfy.NtfyAlerter(ntfy_topic="t", ntfy_token="TOK")
+    post, captured = _fake_post(200)
+    monkeypatch.setattr(requests, "post", post)
+    alerter.send_alert("t", "b")
+    assert captured["headers"]["Authorization"] == "Bearer TOK"
+
+
+def test_unicode_title_is_latin1_safe(monkeypatch: pytest.MonkeyPatch, alerter):
+    """ntfy uses HTTP headers for titles, which must be Latin-1. Discogs titles
+    can contain things like 'Deep²' that requests would reject — we coerce
+    rather than crashing.
+    """
+
+    post, captured = _fake_post(200)
+    monkeypatch.setattr(requests, "post", post)
+    assert alerter.send_alert("Deep² — Sphere", "body") is True
+    captured["headers"]["Title"].encode("latin-1")  # would raise if invalid
+
+
+def test_send_alert_returns_false_on_4xx(monkeypatch: pytest.MonkeyPatch, alerter):
+    post, _ = _fake_post(403, b"forbidden")
+    monkeypatch.setattr(requests, "post", post)
+    assert alerter.send_alert("t", "b") is False
+
+
+def test_send_alert_returns_false_on_request_exception(monkeypatch: pytest.MonkeyPatch, alerter):
+    post, _ = _fake_post(raise_exc=requests.ConnectionError("nope"))
+    monkeypatch.setattr(requests, "post", post)
+    assert alerter.send_alert("t", "b") is False
+
+
+def test_constructor_rejects_empty_topic():
+    with pytest.raises(ValueError):
+        da_ntfy.NtfyAlerter(ntfy_topic="")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -110,6 +110,42 @@ def test_cli_telegram_requires_chat_id(stub_loop, wantlist_file):
     assert "telegram_chat_id" in result.output or "is required" in result.output
 
 
+def test_cli_ntfy_requires_topic(stub_loop, wantlist_file):
+    runner = CliRunner()
+    result = runner.invoke(
+        da_main.main,
+        [
+            "--discogs-token", "TOK",
+            "--wantlist-path", str(wantlist_file),
+            "--alerter-type", "NTFY",
+            "--test",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "ntfy_topic" in result.output or "is required" in result.output
+
+
+def test_cli_ntfy_happy_path(stub_loop, wantlist_file):
+    runner = CliRunner()
+    result = runner.invoke(
+        da_main.main,
+        [
+            "--discogs-token", "TOK",
+            "--wantlist-path", str(wantlist_file),
+            "--alerter-type", "NTFY",
+            "--ntfy-topic", "my-topic",
+            "--test",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert stub_loop["alerter_type"] == "NTFY"
+    assert stub_loop["alerter_kwargs"] == {
+        "ntfy_topic": "my-topic",
+        "ntfy_server": "https://ntfy.sh",
+        "ntfy_token": None,
+    }
+
+
 def test_cli_telegram_happy_path(stub_loop, wantlist_file):
     runner = CliRunner()
     result = runner.invoke(


### PR DESCRIPTION
## Summary
- Adds ntfy.sh as a built-in alerter — lowest-friction alerter we ship (no account, no token).
- Self-host supported via \`--ntfy-server\`; auth via \`--ntfy-token\` for paid / private instances.
- README updated with a "ntfy.sh (lowest-friction)" section.

## Test plan
- [x] 7 new alerter tests (URL formation, custom server, token, latin-1 title coercion, errors).
- [x] 2 new CLI tests (RequiredIf for ntfy_topic; happy path).
- [x] Suite green: 210 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)