### PR TITLE
Add discogs_alert.config: pydantic schema + TOML loader (Phase A)

### DIFF
--- a/discogs_alert/config.py
+++ b/discogs_alert/config.py
@@ -1,0 +1,266 @@
+"""Pydantic-validated configuration for ``discogs_alert``.
+
+The runtime is moving away from a wall of CLI flags toward a single config
+file at ``~/.discogs_alert/config.toml`` (or wherever ``--config`` points).
+This module owns the schema and the load path.
+
+Three layers, applied in priority order:
+
+1. **Defaults** baked into the pydantic model.
+2. **TOML file** at the resolved config path.
+3. **Environment variables** (e.g. ``DA_DISCOGS_TOKEN`` for ``discogs_token``).
+   Env vars win because they're how Docker / CI / launchd inject secrets.
+
+The Mac menu-bar app, when it ships, will write the same TOML file from a
+settings panel — same shape, same loader, same validation. The runtime
+doesn't care which produced it.
+
+Phase A (this module) only adds the schema and loader; the CLI hasn't
+shrunk yet. Phase B will replace most CLI options with ``--config``.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib  # type: ignore[no-redef]
+
+
+DEFAULT_CONFIG_DIR = Path.home() / ".discogs_alert"
+DEFAULT_CONFIG_PATH = DEFAULT_CONFIG_DIR / "config.toml"
+
+DEFAULT_USER_AGENT = "DiscogsAlert/0.0.1 +http://discogsalert.com"
+
+
+class WantlistConfig(BaseModel):
+    """Where the wantlist comes from. Set exactly one of ``list_id`` (a Discogs
+    list) or ``path`` (a local JSON file).
+    """
+
+    list_id: Optional[int] = None
+    path: Optional[str] = None
+
+
+class SellerConfig(BaseModel):
+    min_rating: int = 99
+    min_sales: Optional[int] = None
+
+
+class RecordConfig(BaseModel):
+    min_media_condition: str = "VERY_GOOD"
+    min_sleeve_condition: str = "NOT_GRADED"
+
+
+class CountryFiltersConfig(BaseModel):
+    """Two-character ISO codes (or whichever names appear in
+    ``discogs_alert.util.constants.COUNTRIES``).
+    """
+
+    whitelist: List[str] = Field(default_factory=list)
+    blacklist: List[str] = Field(default_factory=list)
+
+
+class PushbulletConfig(BaseModel):
+    token: Optional[str] = None
+
+
+class TelegramConfig(BaseModel):
+    token: Optional[str] = None
+    chat_id: Optional[str] = None
+
+
+class NtfyConfig(BaseModel):
+    topic: Optional[str] = None
+    server: str = "https://ntfy.sh"
+    token: Optional[str] = None
+
+
+class AlerterConfig(BaseModel):
+    """Choice of alerter and per-alerter configuration.
+
+    Only the section corresponding to ``type`` is used; the others are kept
+    around so a user can switch alerters without losing their config.
+    """
+
+    type: str = "NTFY"
+    pushbullet: PushbulletConfig = Field(default_factory=PushbulletConfig)
+    telegram: TelegramConfig = Field(default_factory=TelegramConfig)
+    ntfy: NtfyConfig = Field(default_factory=NtfyConfig)
+
+
+class RuntimeConfig(BaseModel):
+    """Things the runtime cares about that aren't user preferences."""
+
+    state_path: Optional[str] = None
+    stats_gate: bool = True
+    max_concurrency: int = 6
+    prune_after_days: int = 90
+    verbose: bool = False
+    log_level: str = "INFO"
+
+
+class Config(BaseModel):
+    """Top-level config schema.
+
+    Mirrors the TOML layout::
+
+        discogs_token = "..."
+        country = "Germany"
+        currency = "EUR"
+        frequency = 60
+
+        [wantlist]
+        list_id = 12345
+
+        [seller]
+        min_rating = 99
+
+        [record]
+        min_media_condition = "VERY_GOOD"
+
+        [country_filters]
+        blacklist = ["UK", "US"]
+
+        [alerter]
+        type = "NTFY"
+
+        [alerter.ntfy]
+        topic = "my-secret-topic"
+
+        [runtime]
+        max_concurrency = 6
+    """
+
+    discogs_token: str
+    user_agent: str = DEFAULT_USER_AGENT
+    country: str = "Germany"
+    currency: str = "EUR"
+    frequency: int = 60
+
+    wantlist: WantlistConfig = Field(default_factory=WantlistConfig)
+    seller: SellerConfig = Field(default_factory=SellerConfig)
+    record: RecordConfig = Field(default_factory=RecordConfig)
+    country_filters: CountryFiltersConfig = Field(default_factory=CountryFiltersConfig)
+    alerter: AlerterConfig = Field(default_factory=AlerterConfig)
+    runtime: RuntimeConfig = Field(default_factory=RuntimeConfig)
+
+
+# -- env var override surface ------------------------------------------------
+#
+# Mapping of env var → dotted path into the config dict. Kept explicit (rather
+# than auto-derived from the model) so it's easy to see what's overridable
+# and so a typo can't silently get reflected into config.
+
+_ENV_OVERRIDES = {
+    "DA_DISCOGS_TOKEN": "discogs_token",
+    "DA_USER_AGENT": "user_agent",
+    "DA_COUNTRY": "country",
+    "DA_CURRENCY": "currency",
+    "DA_FREQUENCY": "frequency",
+    "DA_LIST_ID": "wantlist.list_id",
+    "DA_WANTLIST_PATH": "wantlist.path",
+    "DA_MIN_SELLER_RATING": "seller.min_rating",
+    "DA_MIN_SELLER_SALES": "seller.min_sales",
+    "DA_MIN_MEDIA_CONDITION": "record.min_media_condition",
+    "DA_MIN_SLEEVE_CONDITION": "record.min_sleeve_condition",
+    "DA_COUNTRY_WHITELIST": "country_filters.whitelist",
+    "DA_COUNTRY_BLACKLIST": "country_filters.blacklist",
+    "DA_ALERTER_TYPE": "alerter.type",
+    "DA_PUSHBULLET_TOKEN": "alerter.pushbullet.token",
+    "DA_TELEGRAM_TOKEN": "alerter.telegram.token",
+    "DA_TELEGRAM_CHAT_ID": "alerter.telegram.chat_id",
+    "DA_NTFY_TOPIC": "alerter.ntfy.topic",
+    "DA_NTFY_SERVER": "alerter.ntfy.server",
+    "DA_NTFY_TOKEN": "alerter.ntfy.token",
+    "DA_STATE_PATH": "runtime.state_path",
+    "DA_STATS_GATE": "runtime.stats_gate",
+    "DA_MAX_CONCURRENCY": "runtime.max_concurrency",
+    "DA_PRUNE_AFTER_DAYS": "runtime.prune_after_days",
+    "DA_LOG_LEVEL": "runtime.log_level",
+}
+
+
+def _coerce_env_value(env_name: str, raw: str) -> object:
+    """Best-effort coerce a string env var to the right type.
+
+    The pydantic model already does coercion at validate time, so all we need
+    here is to split list-shaped vars (``DA_COUNTRY_WHITELIST="DE FR"``) into
+    actual lists, and pass everything else through as a string. Pydantic
+    handles int / bool / etc.
+    """
+
+    if env_name in {"DA_COUNTRY_WHITELIST", "DA_COUNTRY_BLACKLIST"}:
+        return [piece for piece in raw.split() if piece]
+    return raw
+
+
+def _set_dotted(target: dict, dotted: str, value: object) -> None:
+    """Set ``dotted`` (e.g. ``"alerter.ntfy.topic"``) inside ``target``,
+    creating intermediate dicts as needed.
+    """
+
+    parts = dotted.split(".")
+    cur = target
+    for part in parts[:-1]:
+        cur = cur.setdefault(part, {})
+        if not isinstance(cur, dict):
+            # Should never happen — a TOML file written by humans might still
+            # produce this shape if e.g. `wantlist = "x"` collides with
+            # `[wantlist]`. Surface a clear error.
+            raise ValueError(
+                f"Cannot set {dotted!r}: path segment {part!r} is not a table"
+            )
+    cur[parts[-1]] = value
+
+
+def _apply_env_overrides(data: dict, env: Optional[dict] = None) -> dict:
+    """Layer ``DA_*`` env vars on top of a parsed-TOML dict.
+
+    Returns a new dict; doesn't mutate the input.
+    """
+
+    env = os.environ if env is None else env
+    out = {**data}
+    for env_name, dotted in _ENV_OVERRIDES.items():
+        if (raw := env.get(env_name)) is None:
+            continue
+        _set_dotted(out, dotted, _coerce_env_value(env_name, raw))
+    return out
+
+
+def load_config(
+    path: Optional[Path] = None,
+    env: Optional[dict] = None,
+) -> Config:
+    """Load and validate the config from ``path`` (default
+    ``~/.discogs_alert/config.toml``), applying ``DA_*`` env-var overrides on
+    top.
+
+    Args:
+        path: explicit config file path. ``None`` → ``DEFAULT_CONFIG_PATH``.
+        env: env var mapping (defaults to ``os.environ``). Useful for tests.
+
+    Raises:
+        FileNotFoundError: if neither the file exists nor the env vars supply
+            ``discogs_token`` (and the other required fields).
+        pydantic.ValidationError: if the resolved config doesn't match the
+            schema (missing required fields, wrong types, etc.).
+    """
+
+    resolved_path = path or DEFAULT_CONFIG_PATH
+    if resolved_path.exists():
+        with open(resolved_path, "rb") as f:
+            data = tomllib.load(f)
+    else:
+        data = {}
+
+    data = _apply_env_overrides(data, env=env)
+    return Config.model_validate(data)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ curl_cffi = "^0.7"
 pydantic = "^2.6"
 requests = "^2.32"
 schedule = "^1.2"
+tomli = {version = "^2.0", python = "<3.11"}
 
 [tool.poetry.dev-dependencies]
 pre-commit = "^3.7"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,219 @@
+"""Tests for `discogs_alert.config`.
+
+Covers schema defaults, TOML parsing, env-var overrides, and the priority
+order between the two.
+"""
+
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from discogs_alert import config as da_config
+
+
+def _write_toml(tmp_path: Path, body: str) -> Path:
+    path = tmp_path / "config.toml"
+    path.write_text(body)
+    return path
+
+
+# -- defaults ----------------------------------------------------------------
+
+
+def test_minimal_config_via_env(tmp_path: Path):
+    """Discogs token is the only required field; everything else defaults."""
+
+    cfg = da_config.load_config(
+        path=tmp_path / "no-such-file.toml",
+        env={"DA_DISCOGS_TOKEN": "TOK"},
+    )
+    assert cfg.discogs_token == "TOK"
+    assert cfg.country == "Germany"
+    assert cfg.currency == "EUR"
+    assert cfg.frequency == 60
+    assert cfg.alerter.type == "NTFY"
+    assert cfg.runtime.max_concurrency == 6
+    assert cfg.runtime.prune_after_days == 90
+    assert cfg.seller.min_rating == 99
+    assert cfg.country_filters.blacklist == []
+
+
+def test_missing_discogs_token_raises(tmp_path: Path):
+    with pytest.raises(ValidationError) as exc:
+        da_config.load_config(path=tmp_path / "no-such-file.toml", env={})
+    assert "discogs_token" in str(exc.value)
+
+
+# -- TOML parsing ------------------------------------------------------------
+
+
+def test_loads_full_toml(tmp_path: Path):
+    config_path = _write_toml(
+        tmp_path,
+        """
+        discogs_token = "FROM_FILE"
+        country = "France"
+        currency = "GBP"
+        frequency = 30
+
+        [wantlist]
+        list_id = 12345
+
+        [seller]
+        min_rating = 95
+        min_sales = 50
+
+        [record]
+        min_media_condition = "NEAR_MINT"
+        min_sleeve_condition = "VERY_GOOD"
+
+        [country_filters]
+        blacklist = ["UK", "US"]
+        whitelist = ["FR"]
+
+        [alerter]
+        type = "NTFY"
+
+        [alerter.ntfy]
+        topic = "my-topic"
+        server = "https://ntfy.example.com"
+
+        [runtime]
+        max_concurrency = 12
+        prune_after_days = 30
+        verbose = true
+        log_level = "DEBUG"
+        """,
+    )
+    cfg = da_config.load_config(path=config_path, env={})
+    assert cfg.discogs_token == "FROM_FILE"
+    assert cfg.country == "France"
+    assert cfg.currency == "GBP"
+    assert cfg.frequency == 30
+    assert cfg.wantlist.list_id == 12345
+    assert cfg.seller.min_rating == 95
+    assert cfg.seller.min_sales == 50
+    assert cfg.record.min_media_condition == "NEAR_MINT"
+    assert cfg.country_filters.blacklist == ["UK", "US"]
+    assert cfg.alerter.type == "NTFY"
+    assert cfg.alerter.ntfy.topic == "my-topic"
+    assert cfg.alerter.ntfy.server == "https://ntfy.example.com"
+    assert cfg.runtime.max_concurrency == 12
+    assert cfg.runtime.verbose is True
+    assert cfg.runtime.log_level == "DEBUG"
+
+
+def test_unknown_top_level_keys_ignored(tmp_path: Path):
+    """Pydantic's default is to ignore extra keys, so a TOML file with new
+    unrecognised settings doesn't break older runtimes.
+    """
+
+    config_path = _write_toml(
+        tmp_path,
+        """
+        discogs_token = "T"
+        future_feature = "future"
+
+        [some_unknown_section]
+        x = 1
+        """,
+    )
+    cfg = da_config.load_config(path=config_path, env={})
+    assert cfg.discogs_token == "T"
+
+
+# -- env var overrides -------------------------------------------------------
+
+
+def test_env_overrides_toml_value(tmp_path: Path):
+    """Env vars win over the file. Useful for Docker / CI / launchd."""
+
+    config_path = _write_toml(tmp_path, 'discogs_token = "FROM_FILE"\ncountry = "France"\n')
+    cfg = da_config.load_config(
+        path=config_path,
+        env={"DA_DISCOGS_TOKEN": "FROM_ENV", "DA_COUNTRY": "Spain"},
+    )
+    assert cfg.discogs_token == "FROM_ENV"
+    assert cfg.country == "Spain"
+
+
+def test_env_supplies_token_when_file_omits_it(tmp_path: Path):
+    config_path = _write_toml(tmp_path, 'country = "France"\n')
+    cfg = da_config.load_config(path=config_path, env={"DA_DISCOGS_TOKEN": "FROM_ENV"})
+    assert cfg.discogs_token == "FROM_ENV"
+    assert cfg.country == "France"
+
+
+def test_nested_env_override(tmp_path: Path):
+    """A `DA_NTFY_TOPIC` env var should land in `cfg.alerter.ntfy.topic`."""
+
+    cfg = da_config.load_config(
+        path=tmp_path / "no.toml",
+        env={
+            "DA_DISCOGS_TOKEN": "T",
+            "DA_NTFY_TOPIC": "via-env",
+            "DA_MAX_CONCURRENCY": "12",
+        },
+    )
+    assert cfg.alerter.ntfy.topic == "via-env"
+    assert cfg.runtime.max_concurrency == 12
+
+
+def test_country_list_env_var_splits_on_whitespace(tmp_path: Path):
+    """`DA_COUNTRY_BLACKLIST="UK US"` should produce a 2-element list."""
+
+    cfg = da_config.load_config(
+        path=tmp_path / "no.toml",
+        env={"DA_DISCOGS_TOKEN": "T", "DA_COUNTRY_BLACKLIST": "UK  US DE"},
+    )
+    assert cfg.country_filters.blacklist == ["UK", "US", "DE"]
+
+
+def test_empty_country_list_env_var_yields_empty_list(tmp_path: Path):
+    cfg = da_config.load_config(
+        path=tmp_path / "no.toml",
+        env={"DA_DISCOGS_TOKEN": "T", "DA_COUNTRY_BLACKLIST": ""},
+    )
+    assert cfg.country_filters.blacklist == []
+
+
+def test_bool_env_var_coerced_by_pydantic(tmp_path: Path):
+    """Pydantic coerces ``"true"`` → True at validate time."""
+
+    cfg = da_config.load_config(
+        path=tmp_path / "no.toml",
+        env={"DA_DISCOGS_TOKEN": "T", "DA_STATS_GATE": "false"},
+    )
+    assert cfg.runtime.stats_gate is False
+
+
+def test_int_env_var_coerced_by_pydantic(tmp_path: Path):
+    cfg = da_config.load_config(
+        path=tmp_path / "no.toml",
+        env={"DA_DISCOGS_TOKEN": "T", "DA_PRUNE_AFTER_DAYS": "30"},
+    )
+    assert cfg.runtime.prune_after_days == 30
+
+
+# -- internal helpers --------------------------------------------------------
+
+
+def test_set_dotted_creates_nested_dicts():
+    target: dict = {}
+    da_config._set_dotted(target, "alerter.ntfy.topic", "x")
+    assert target == {"alerter": {"ntfy": {"topic": "x"}}}
+
+
+def test_set_dotted_rejects_path_through_non_dict():
+    target = {"alerter": "not-a-table"}
+    with pytest.raises(ValueError):
+        da_config._set_dotted(target, "alerter.ntfy.topic", "x")
+
+
+# -- default path resolution -------------------------------------------------
+
+
+def test_default_path_is_under_home():
+    assert da_config.DEFAULT_CONFIG_PATH.name == "config.toml"
+    assert da_config.DEFAULT_CONFIG_PATH.parent.name == ".discogs_alert"


### PR DESCRIPTION
## Summary
Phase A of the move toward a single config file at \`~/.discogs_alert/config.toml\`. Defines the schema and the loader; the CLI hasn't shrunk yet (Phase B).

The schema mirrors what the eventual menu-bar app will write — same shape, same loader, same validation, regardless of producer.

**Three layers, applied in priority order:**
1. Pydantic defaults
2. TOML file
3. \`DA_*\` env vars (Docker / launchd / CI workflows still work)

## Test plan
- [x] 14 new tests in \`tests/test_config.py\` covering defaults, full TOML, env overrides, nested keys, list-shaped env vars, type coercion, missing required fields.
- [x] Suite green: 236 passed, coverage 90.72% (above 88% gate).

## What this enables
- Phase B (next PR): slim the CLI down to \`--config\`, \`--once\`, \`--validate-config\`, \`--init\`. Old flags become deprecated overrides for one cycle.
- Mac menu-bar app: writes \`config.toml\`, runtime reads it. Same config, runs anywhere (Mac / Pi / Docker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)