### PR TITLE
Config Phase B: slim CLI + pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,39 @@
+# Pre-commit hooks. Mirror as much of CI as we cheaply can so failures
+# surface locally before push. The full tox / coverage matrix only runs
+# on CI; here we run the fast subset (lint + offline tests).
+#
+# Bypass with `git commit --no-verify` if you really need to.
+
 repos:
 
-# run ruff style, import-order, & general linting checks
-- repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: 'v0.0.249'
+# Ruff: lint + import-order + tidy-imports. Mirrors the `ruff (Python 3.x)`
+# CI matrix — same config (`[tool.ruff]` in pyproject.toml).
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.6.9
   hooks:
     - id: ruff
+      args: ["--fix"]
 
-# check that pyproject.toml is a valid poetry config file
+# pyproject.toml stays a valid Poetry file.
 - repo: https://github.com/python-poetry/poetry
-  rev: '1.3.0'
+  rev: '1.8.4'
   hooks:
     - id: poetry-check
+
+# Run the offline test subset locally before commit. The full suite
+# (tox across 3.10–3.13 with coverage gating) still runs on CI; this
+# catches the >90% case where someone broke a test in the file they
+# just edited. ~1 second on the current 250-test suite.
+#
+# Uses `local` so we use the project's own pytest install (matches
+# what tests/ expect) rather than a hook-managed env where deps aren't
+# installed.
+- repo: local
+  hooks:
+    - id: pytest-offline
+      name: pytest (offline)
+      entry: python -m pytest -q -m "not online"
+      language: system
+      pass_filenames: false
+      types: [python]
+      stages: [pre-commit]

--- a/discogs_alert/__main__.py
+++ b/discogs_alert/__main__.py
@@ -1,275 +1,120 @@
+"""Slim CLI entry point.
+
+Configuration lives in ``~/.discogs_alert/config.toml`` (or wherever
+``--config`` points), with ``DA_*`` env vars layered on top — see
+``discogs_alert/config.py`` and ``examples/config.example.toml``.
+
+The CLI itself is intentionally tiny: a config file, a ``--once`` switch
+for cron / launchd / systemd-timer use, a ``--verbose`` shortcut for
+log-level bumping, and a couple of debug helpers (``--validate-config``,
+``--print-config``). Anything richer goes in the TOML file.
+"""
+
+from __future__ import annotations
+
 import asyncio
+import json
 import logging
+import sys
+from pathlib import Path
+from typing import Optional
 
 import click
+from pydantic import ValidationError
 
 from discogs_alert import (
     __version__,
-    alert as da_alert,
     client as da_client,
+    config as da_config,
     entities as da_entities,
     loop as da_loop,
 )
-from discogs_alert.util import click as da_click, constants as dac
+from discogs_alert.util import constants as dac
 
 logger = logging.getLogger(__name__)
 
 
+def _load_or_die(config_path: Optional[Path]) -> da_config.Config:
+    """Load the config file (or env-var defaults) and exit cleanly with a
+    helpful message on validation failure.
+
+    `load_config` doesn't raise on a missing file — it just falls through
+    to env-var defaults. The only failure shape we wrap here is the
+    `ValidationError` you get when neither the file nor env vars supply
+    the required fields (e.g. `discogs_token`).
+    """
+
+    try:
+        return da_config.load_config(path=config_path)
+    except ValidationError as exc:
+        click.echo("Invalid config:", err=True)
+        click.echo(str(exc), err=True)
+        click.echo(
+            f"\nTip: copy examples/config.example.toml to "
+            f"{da_config.DEFAULT_CONFIG_PATH} and edit, or set the "
+            "required DA_* environment variables.",
+            err=True,
+        )
+        sys.exit(2)
+
+
+def _build_loop_kwargs(cfg: da_config.Config) -> dict:
+    """Translate the validated Config into the kwargs that ``loop.loop`` accepts."""
+
+    alerter_type = cfg.alerter.type.upper()
+    alerter_kwargs: dict = {}
+    if alerter_type == "PUSHBULLET":
+        alerter_kwargs = {"pushbullet_token": cfg.alerter.pushbullet.token}
+    elif alerter_type == "TELEGRAM":
+        alerter_kwargs = {
+            "telegram_token": cfg.alerter.telegram.token,
+            "telegram_chat_id": cfg.alerter.telegram.chat_id,
+        }
+    elif alerter_type == "NTFY":
+        alerter_kwargs = {
+            "ntfy_topic": cfg.alerter.ntfy.topic,
+            "ntfy_server": cfg.alerter.ntfy.server,
+            "ntfy_token": cfg.alerter.ntfy.token,
+        }
+
+    return dict(
+        discogs_token=cfg.discogs_token,
+        list_id=cfg.wantlist.list_id,
+        wantlist_path=cfg.wantlist.path,
+        user_agent=cfg.user_agent,
+        country=cfg.country,
+        currency=cfg.currency,
+        seller_filters=da_entities.SellerFilters(
+            min_seller_rating=cfg.seller.min_rating,
+            min_seller_sales=cfg.seller.min_sales,
+        ),
+        record_filters=da_entities.RecordFilters(
+            min_media_condition=da_entities.CONDITION[cfg.record.min_media_condition],
+            min_sleeve_condition=da_entities.CONDITION[cfg.record.min_sleeve_condition],
+        ),
+        country_whitelist=set(dac.COUNTRIES[c] for c in cfg.country_filters.whitelist),
+        country_blacklist=set(dac.COUNTRIES[c] for c in cfg.country_filters.blacklist),
+        alerter_type=alerter_type,
+        alerter_kwargs=alerter_kwargs,
+        state_path=cfg.runtime.state_path,
+        use_stats_gate=cfg.runtime.stats_gate,
+        max_concurrency=cfg.runtime.max_concurrency,
+        prune_after_days=cfg.runtime.prune_after_days,
+        verbose=cfg.runtime.verbose,
+    )
+
+
 @click.command()
 @click.option(
-    "-dt",
-    "--discogs-token",
-    required=True,
-    type=str,
-    envvar="DA_DISCOGS_TOKEN",
-    help="unique discogs user access token (enabling sending of requests on your behalf)",
-)
-@click.option(
-    "-lid",
-    "--list-id",
-    type=int,
-    envvar="DA_LIST_ID",
-    cls=da_click.NotRequiredIf,
-    not_required_if="wantlist-path",
-    help="ID of Discogs list to use as wantlist",
-)
-@click.option(
-    "-wp",
-    "--wantlist-path",
-    type=click.Path(exists=True),
-    envvar="DA_WANTLIST_PATH",
-    cls=da_click.NotRequiredIf,
-    not_required_if="list-id",
-    help="path to your wantlist json file (including filename)",
-)
-@click.option(
-    "-ua",
-    "--user-agent",
-    default="DiscogsAlert/0.0.1 +http://discogsalert.com",
-    type=str,
-    envvar="DA_USER_AGENT",
-    help="user-agent indicating source of HTTP request",
-)
-@click.option(
-    "-f",
-    "--frequency",
-    default=60,
-    show_default=True,
-    type=click.IntRange(1, 60),
-    envvar="DA_FREQUENCY",
-    help="number of times per hour to check the marketplace",
-)
-@click.option(
-    "-co",
-    "--country",
-    default="Germany",
-    show_default=True,
-    type=str,
-    envvar="DA_COUNTRY",
-    help="country where you live (e.g. for shipping availability)",
-)
-@click.option(
-    "-$",
-    "--currency",
-    default="EUR",
-    show_default=True,
-    envvar="DA_CURRENCY",
-    type=click.Choice(dac.CURRENCY_CHOICES),
-    help="preferred currency (to convert all others to)",
-)
-@click.option(
-    "-msr",
-    "--min-seller-rating",
-    default=99,
-    show_default=True,
-    type=int,
-    envvar="DA_MIN_SELLER_RATING",
-    help="minimum seller rating you want to allow",
-)
-@click.option(
-    "-mss",
-    "--min-seller-sales",
+    "-c",
+    "--config",
+    "config_path",
     default=None,
-    show_default=True,
-    type=int,
-    envvar="DA_MIN_SELLER_SALES",
-    help="minimum number of seller sales you want to allow",
-)
-@click.option(
-    "-mmc",
-    "--min-media-condition",
-    default=da_entities.CONDITION.VERY_GOOD.name,
-    show_default=True,
-    envvar="DA_MIN_MEDIA_CONDITION",
-    type=da_click.EnumChoice(da_entities.CONDITION),
-    help="minimum media condition you want to accept",
-)
-@click.option(
-    "-msc",
-    "--min-sleeve-condition",
-    default=da_entities.CONDITION.NOT_GRADED.name,
-    show_default=True,
-    envvar="DA_MIN_SLEEVE_CONDITION",
-    type=da_click.EnumChoice(da_entities.CONDITION),
-    help="minimum sleeve condition you want to accept",
-)
-@click.option(
-    "-wl",
-    "--country-whitelist",
-    multiple=True,
-    default=[],
-    envvar="DA_COUNTRY_WHITELIST",
-    type=click.Choice(dac.COUNTRY_CHOICES),
+    type=click.Path(dir_okay=False, file_okay=True, path_type=Path),
+    envvar="DA_CONFIG_PATH",
     help=(
-        "If any countries are passed in the whitelist, you'll _only_ be alerted about listings by sellers of those "
-        "countries (e.g. if you live in the USA and only want to consider releases for sale in the USA). To specify a "
-        "whitelist as an environment variable you must use a string with whitespace, for example "
-        '`export DA_COUNTRY_WHITELIST="DE US"`.'
-    ),
-)
-@click.option(
-    "-bl",
-    "--country-blacklist",
-    multiple=True,
-    default=[],
-    envvar="DA_COUNTRY_BLACKLIST",
-    type=click.Choice(dac.COUNTRY_CHOICES),
-    help=(
-        "If any countries are passed in the blacklist, you'll be alerted about listings by sellers of all countries "
-        "excluding those excluding those, e.g. if you live in Germany and don't want to consider releases from the UK "
-        "due to import taxes. To specify a blacklist as an environment variable you must use a string with whitespace, "
-        'for example `export DA_COUNTRY_BLACKLIST="UK US"`. If you have a country in both the blacklist and the '
-        "whitelist, the blacklist wins."
-    ),
-)
-@click.option(
-    "-at",
-    "--alerter-type",
-    required=True,
-    envvar="DA_ALERTER_TYPE",
-    type=click.Choice(da_alert.alerter_names(), case_sensitive=False),
-    help="Your choice of alerting service. Please see the Alerters section in the README for more information",
-)
-@click.option(
-    "-pt",
-    "--pushbullet-token",
-    cls=da_click.RequiredIf,
-    required_if=lambda x: str(x.get("alerter_type", "")).upper() == "PUSHBULLET",
-    required_if_str="alerter_type=PUSHBULLET",
-    type=str,
-    envvar="DA_PUSHBULLET_TOKEN",
-    help="token for pushbullet notification service.",
-)
-@click.option(
-    "-tt",
-    "--telegram-token",
-    cls=da_click.RequiredIf,
-    required_if=lambda x: str(x.get("alerter_type", "")).upper() == "TELEGRAM",
-    required_if_str="alerter_type=TELEGRAM",
-    type=str,
-    envvar="DA_TELEGRAM_TOKEN",
-    help="token for telegram bot notification service.",
-)
-@click.option(
-    "-tci",
-    "--telegram-chat-id",
-    cls=da_click.RequiredIf,
-    required_if=lambda x: str(x.get("alerter_type", "")).upper() == "TELEGRAM",
-    required_if_str="alerter_type=TELEGRAM",
-    type=str,
-    envvar="DA_TELEGRAM_CHAT_ID",
-    help="chat ID for telegram bot notification service.",
-)
-@click.option(
-    "--ntfy-topic",
-    cls=da_click.RequiredIf,
-    required_if=lambda x: str(x.get("alerter_type", "")).upper() == "NTFY",
-    required_if_str="alerter_type=NTFY",
-    type=str,
-    envvar="DA_NTFY_TOPIC",
-    help=(
-        "ntfy.sh topic name (anything random and hard-to-guess works — anyone "
-        "with the topic name can read your notifications). Subscribe to the "
-        "same topic from the ntfy iOS / Android / desktop / web app."
-    ),
-)
-@click.option(
-    "--ntfy-server",
-    default="https://ntfy.sh",
-    show_default=True,
-    type=str,
-    envvar="DA_NTFY_SERVER",
-    help="ntfy server URL. Override to point at a self-hosted instance.",
-)
-@click.option(
-    "--ntfy-token",
-    default=None,
-    type=str,
-    envvar="DA_NTFY_TOKEN",
-    help=(
-        "Optional ntfy access token (only needed for self-hosted instances "
-        "with auth enabled, or paid ntfy.sh tiers)."
-    ),
-)
-@click.option(
-    "-sp",
-    "--state-path",
-    default=None,
-    type=click.Path(dir_okay=False, file_okay=True),
-    envvar="DA_STATE_PATH",
-    help=(
-        "Path to the local SQLite database used to deduplicate alerts. "
-        "Defaults to `~/.discogs_alert/state.db`."
-    ),
-)
-@click.option(
-    "--stats-gate/--no-stats-gate",
-    default=True,
-    show_default=True,
-    envvar="DA_STATS_GATE",
-    help=(
-        "Use the cheap `/marketplace/stats` API to skip the expensive marketplace "
-        "scrape for releases with no listings or above your price threshold. "
-        "Recommended; disable only for debugging."
-    ),
-)
-@click.option(
-    "--max-concurrency",
-    default=da_loop.DEFAULT_MAX_CONCURRENCY,
-    show_default=True,
-    type=click.IntRange(min=1, max=32),
-    envvar="DA_MAX_CONCURRENCY",
-    help=(
-        "Maximum number of concurrent marketplace scrapes per loop iteration. "
-        "Higher values are faster but more likely to trip Cloudflare's bot "
-        "detection on large wantlists. The default is conservative."
-    ),
-)
-@click.option(
-    "--prune-after-days",
-    default=90,
-    show_default=True,
-    type=click.IntRange(min=0),
-    envvar="DA_PRUNE_AFTER_DAYS",
-    help=(
-        "On startup, drop dedup records older than this many days from the local "
-        "state database. Listings disappear from Discogs long before this, so "
-        "older rows can't ever match a future listing. Set to 0 to disable."
-    ),
-)
-@click.option(
-    "-V", "--verbose", default=False, is_flag=True, help="use flag if you want to see logs as the program runs"
-)
-@click.option(
-    "-l",
-    "--log-level",
-    default=None,
-    envvar="DA_LOG_LEVEL",
-    type=click.Choice(["DEBUG", "INFO", "WARNING", "ERROR"], case_sensitive=False),
-    help=(
-        "Override the root log level. Useful for quieting `INFO` chatter under cron "
-        "(`--log-level=WARNING`) or capturing extra detail when debugging "
-        "(`--log-level=DEBUG`). When omitted, defaults to INFO."
+        "Path to a TOML config file. Defaults to ~/.discogs_alert/config.toml. "
+        "See examples/config.example.toml for the schema."
     ),
 )
 @click.option(
@@ -280,112 +125,75 @@ logger = logging.getLogger(__name__)
     is_flag=True,
     envvar="DA_ONCE",
     help=(
-        "Run the loop exactly once and exit, instead of scheduling it to repeat. "
-        "Useful when you're driving discogs_alert from cron / systemd-timer / "
-        "launchd and want the schedule managed externally."
+        "Run the loop exactly once and exit. Use with cron / launchd / "
+        "systemd-timer when you want the schedule managed externally."
     ),
 )
 @click.option(
-    "-T",
-    "--test",
-    "test",
+    "-V",
+    "--verbose",
+    "verbose",
     default=False,
     is_flag=True,
-    hidden=True,
-    help="Deprecated alias for --once; kept for backward compatibility.",
+    help="Shortcut for `--log-level=DEBUG` and `runtime.verbose=true`.",
+)
+@click.option(
+    "-l",
+    "--log-level",
+    default=None,
+    envvar="DA_LOG_LEVEL",
+    type=click.Choice(["DEBUG", "INFO", "WARNING", "ERROR"], case_sensitive=False),
+    help="Override the root log level.",
+)
+@click.option(
+    "--validate-config",
+    is_flag=True,
+    help="Load and validate the config, print a one-line summary, and exit.",
+)
+@click.option(
+    "--print-config",
+    is_flag=True,
+    help="Load the config, dump the resolved values as JSON, and exit.",
 )
 @click.version_option(__version__)
 def main(
-    discogs_token,
-    list_id,
-    wantlist_path,
-    user_agent,
-    frequency,
-    country,
-    currency,
-    min_seller_rating,
-    min_seller_sales,
-    min_media_condition,
-    min_sleeve_condition,
-    country_whitelist,
-    country_blacklist,
-    alerter_type,
-    pushbullet_token,
-    telegram_token,
-    telegram_chat_id,
-    ntfy_topic,
-    ntfy_server,
-    ntfy_token,
-    state_path,
-    stats_gate,
-    max_concurrency,
-    prune_after_days,
-    verbose,
-    log_level,
-    once,
-    test,
-):
-    """
-    This loop queries your watchlist at regular intervals, alerting you if a release satisfying your criteria is found.
+    config_path: Optional[Path],
+    once: bool,
+    verbose: bool,
+    log_level: Optional[str],
+    validate_config: bool,
+    print_config: bool,
+) -> None:
+    """Run the discogs_alert loop, configured by a TOML file + env vars.
+
+    Quick start:
+
+      \b
+      cp examples/config.example.toml ~/.discogs_alert/config.toml
+      $EDITOR ~/.discogs_alert/config.toml
+      python -m discogs_alert
     """
 
-    # Configure logging here, not at module import — importing the package
-    # shouldn't install a global handler on the root logger.
     logging.basicConfig(level=logging.INFO)
+    cfg = _load_or_die(config_path)
 
-    # `--once` is the canonical name; `--test` is the legacy alias.
-    one_shot = once or test
-
-    # Apply log-level override on top of the basicConfig above.
+    # Apply CLI overrides on top of the loaded config.
+    if verbose:
+        cfg.runtime.verbose = True
+        if log_level is None:
+            log_level = "DEBUG"
     if log_level is not None:
         logging.getLogger().setLevel(log_level.upper())
 
-    # if both a list ID and a local wantlist path are provided, use the wantlist (to force-enable local testing)
-    if list_id is not None and wantlist_path is not None:
-        list_id = None
+    if validate_config:
+        click.echo(f"Config valid. Alerter: {cfg.alerter.type}, frequency: {cfg.frequency}/h")
+        return
 
-    # `alerter_type` arrives as a string from `click.Choice`. Built-in alerters
-    # have explicit CLI options for their kwargs; plugin alerters (registered
-    # via the `discogs_alert.alerters` entry point) read their own config from
-    # env vars or wherever they like — we just pass an empty kwargs dict.
-    alerter_type = alerter_type.upper()
-    if alerter_type == "PUSHBULLET":
-        alerter_kwargs = {"pushbullet_token": pushbullet_token}
-    elif alerter_type == "TELEGRAM":
-        alerter_kwargs = {"telegram_token": telegram_token, "telegram_chat_id": telegram_chat_id}
-    elif alerter_type == "NTFY":
-        alerter_kwargs = {
-            "ntfy_topic": ntfy_topic,
-            "ntfy_server": ntfy_server,
-            "ntfy_token": ntfy_token,
-        }
-    else:
-        # Plugin alerter — its constructor is responsible for its own config.
-        alerter_kwargs = {}
+    if print_config:
+        click.echo(json.dumps(cfg.model_dump(), indent=2, default=str))
+        return
 
-    loop_kwargs = dict(
-        discogs_token=discogs_token,
-        list_id=list_id,
-        wantlist_path=wantlist_path,
-        user_agent=user_agent,
-        country=country,
-        currency=currency,
-        seller_filters=da_entities.SellerFilters(
-            min_seller_rating=min_seller_rating, min_seller_sales=min_seller_sales
-        ),
-        record_filters=da_entities.RecordFilters(
-            min_media_condition=min_media_condition, min_sleeve_condition=min_sleeve_condition
-        ),
-        country_whitelist=set(dac.COUNTRIES[c] for c in country_whitelist),
-        country_blacklist=set(dac.COUNTRIES[c] for c in country_blacklist),
-        alerter_type=alerter_type,
-        alerter_kwargs=alerter_kwargs,
-        state_path=state_path,
-        use_stats_gate=stats_gate,
-        max_concurrency=max_concurrency,
-        prune_after_days=prune_after_days,
-        verbose=verbose,
-    )
+    loop_kwargs = _build_loop_kwargs(cfg)
 
     logger.info(
         r"""
@@ -400,20 +208,19 @@ def main(
 """
     )
 
-    interval_seconds = max(1, int(3600 / frequency))
-    asyncio.run(_run(loop_kwargs, run_once=one_shot, interval_seconds=interval_seconds))
+    interval_seconds = max(1, int(3600 / cfg.frequency))
+    asyncio.run(_run(loop_kwargs, run_once=once, interval_seconds=interval_seconds, cfg=cfg))
 
 
-async def _run(loop_kwargs: dict, run_once: bool, interval_seconds: int) -> None:
+async def _run(
+    loop_kwargs: dict, run_once: bool, interval_seconds: int, cfg: da_config.Config
+) -> None:
     """Drive the async loop. Holds a single ``UserTokenClient`` and ``AnonClient``
-    across all iterations so TLS handshakes are paid once per process rather
-    than once per iteration.
+    across all iterations so TLS handshakes amortize.
     """
 
-    user_token_client = da_client.UserTokenClient(
-        loop_kwargs["user_agent"], loop_kwargs["discogs_token"]
-    )
-    anon_client = da_client.AnonClient(loop_kwargs["user_agent"])
+    user_token_client = da_client.UserTokenClient(cfg.user_agent, cfg.discogs_token)
+    anon_client = da_client.AnonClient(cfg.user_agent)
     try:
         await da_loop.loop(
             **loop_kwargs,

--- a/examples/config.example.toml
+++ b/examples/config.example.toml
@@ -1,0 +1,109 @@
+# discogs_alert config — copy to ~/.discogs_alert/config.toml and edit.
+#
+# Environment variables (DA_*) override individual fields here, so secrets
+# can stay out of the file (Docker / launchd / CI workflows). See
+# `discogs_alert/config.py` for the full DA_* mapping.
+
+# ---- required ---------------------------------------------------------------
+
+# Your Discogs user-token (https://www.discogs.com/settings/developers).
+# Can also be set via $DA_DISCOGS_TOKEN.
+discogs_token = "REPLACE_ME"
+
+# ---- general ----------------------------------------------------------------
+
+# Country you ship to — used for shipping availability and the country
+# whitelist / blacklist (see [country_filters] below).
+country = "Germany"
+
+# Preferred currency for price comparisons. Listings in other currencies
+# are converted via Frankfurter (https://www.frankfurter.app).
+currency = "EUR"
+
+# How many times per hour to query the marketplace. 60 = once a minute.
+frequency = 60
+
+# Optional: override the user-agent string sent on anonymous marketplace
+# requests. The default identifies discogs_alert and a placeholder URL;
+# customising it is polite to Discogs.
+# user_agent = "DiscogsAlert/0.1.0 +http://my-site.example.com"
+
+# ---- wantlist ---------------------------------------------------------------
+
+# Set exactly ONE of these — `list_id` (a Discogs list) or `path` (a local
+# JSON file). See README for the wantlist.json format.
+
+[wantlist]
+list_id = 12345
+# path = "/Users/me/.discogs_alert/wantlist.json"
+
+# ---- seller filters ---------------------------------------------------------
+
+[seller]
+min_rating = 99      # 0–100; only alert on sellers with this rating or better
+# min_sales = 100    # uncomment to require a minimum number of completed sales
+
+# ---- record condition filters ----------------------------------------------
+
+[record]
+# One of: POOR, FAIR, GOOD, GOOD_PLUS, VERY_GOOD, VERY_GOOD_PLUS, NEAR_MINT, MINT
+min_media_condition = "VERY_GOOD"
+min_sleeve_condition = "NOT_GRADED"  # NOT_GRADED is the most permissive
+
+# ---- country filters --------------------------------------------------------
+#
+# Two-letter ISO country codes. The blacklist wins when both are set.
+# Leave both empty (or omit the section) to alert on listings from anywhere.
+
+[country_filters]
+whitelist = []
+blacklist = ["UK", "US"]   # e.g. avoid customs / tariff hassle
+
+# ---- alerter ----------------------------------------------------------------
+#
+# `type` selects which alerter to use; only the matching sub-section's
+# config is read. Built-ins: NTFY, PUSHBULLET, TELEGRAM. Plugin alerters
+# (entry-point) are also valid here — see docs/writing-an-alerter.md.
+
+[alerter]
+type = "NTFY"
+
+[alerter.ntfy]
+# Pick something random and hard-to-guess — anyone with the topic name
+# can read your notifications.
+topic = "REPLACE_ME"
+server = "https://ntfy.sh"
+# token = "..."   # only for paid ntfy.sh tiers / self-hosted with auth
+
+[alerter.pushbullet]
+# token = "..."
+
+[alerter.telegram]
+# token = "..."
+# chat_id = "..."
+
+# ---- runtime ---------------------------------------------------------------
+
+[runtime]
+# Path to the local SQLite dedup database. Defaults to
+# ~/.discogs_alert/state.db.
+# state_path = "/Users/me/.discogs_alert/state.db"
+
+# Use the cheap /marketplace/stats API to skip the expensive scrape for
+# releases with no listings or above your price threshold. Recommended.
+stats_gate = true
+
+# Cap parallel marketplace scrapes per iteration. Higher is faster but
+# more likely to trip Cloudflare's bot detection on large wantlists.
+max_concurrency = 6
+
+# On startup, drop dedup records older than this many days. Set to 0 to
+# disable. Discogs listings disappear long before 90 days so older rows
+# can never match a new listing.
+prune_after_days = 90
+
+# Verbose logs (per-iteration stats, skip reasons, listing decisions).
+verbose = false
+
+# Root log level. Overridden by --log-level on the CLI.
+log_level = "INFO"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,292 +1,135 @@
-"""Tests for the CLI in `discogs_alert.__main__`.
+"""Tests for the slim CLI in `discogs_alert.__main__`.
 
-Uses Click's `CliRunner` to invoke `main` without hitting any real network or
-filesystem state. The actual `loop` function is monkey-patched out so we just
-verify CLI parsing, validation, and the arg-shaping that happens before
-`da_loop.loop` is called.
+The CLI got a lot smaller in Phase B of the config-file refactor — most
+behaviour now lives in the TOML config and the `DA_*` env-var overrides,
+both of which are tested in `tests/test_config.py`. Here we only check
+the CLI's job: load → optional `--once` / `--validate-config` /
+`--print-config` → kick the loop.
 """
 
+from __future__ import annotations
+
+import json
+import os
 from pathlib import Path
 
 import pytest
 from click.testing import CliRunner
 
-from discogs_alert import __main__ as da_main, entities as da_entities, loop as da_loop
+from discogs_alert import __main__ as da_main
+
+
+@pytest.fixture(autouse=True)
+def _clear_da_env(monkeypatch: pytest.MonkeyPatch):
+    """Strip inherited DA_* env vars so each test starts from a clean slate."""
+
+    for key in list(os.environ):
+        if key.startswith("DA_"):
+            monkeypatch.delenv(key, raising=False)
 
 
 @pytest.fixture
-def stub_loop(monkeypatch: pytest.MonkeyPatch):
-    """Capture the kwargs the CLI hands to `da_loop.loop` and bypass execution.
-
-    The loop is now async, so the stub is async too. We strip ``user_token_client``
-    and ``client_anon`` from the captured kwargs so assertion-by-equality still
-    works — `__main__._run` injects them, but they're implementation details
-    not user input.
-    """
+def stub_run(monkeypatch: pytest.MonkeyPatch):
+    """Capture the kwargs `_run` is called with, without actually running it."""
 
     captured: dict = {}
 
-    async def fake_loop(**kwargs):
-        kwargs.pop("user_token_client", None)
-        kwargs.pop("client_anon", None)
-        captured.update(kwargs)
+    async def fake_run(loop_kwargs, run_once, interval_seconds, cfg):
+        captured["loop_kwargs"] = loop_kwargs
+        captured["run_once"] = run_once
+        captured["interval_seconds"] = interval_seconds
+        captured["cfg"] = cfg
 
-    monkeypatch.setattr(da_loop, "loop", fake_loop)
-    monkeypatch.setattr(da_main.da_loop, "loop", fake_loop)
+    monkeypatch.setattr(da_main, "_run", fake_run)
     return captured
 
 
 @pytest.fixture
-def wantlist_file(tmp_path: Path) -> Path:
-    path = tmp_path / "wantlist.json"
-    path.write_text('[{"id": 1, "display_title": "X"}]')
+def config_file(tmp_path: Path) -> Path:
+    """Minimal valid config file."""
+
+    path = tmp_path / "config.toml"
+    path.write_text(
+        """
+        discogs_token = "TOK"
+        country = "France"
+        currency = "GBP"
+
+        [wantlist]
+        list_id = 42
+
+        [alerter]
+        type = "NTFY"
+        [alerter.ntfy]
+        topic = "x"
+        """
+    )
     return path
 
 
-def _base_args(wantlist_file: Path) -> list[str]:
-    return [
-        "--discogs-token", "TOK",
-        "--wantlist-path", str(wantlist_file),
-        "--alerter-type", "PUSHBULLET",
-        "--pushbullet-token", "PB",
-        "--test",
-    ]
-
-
-def test_cli_runs_with_minimal_required_args(stub_loop, wantlist_file):
+def test_cli_loads_config_and_starts_loop(stub_run, config_file):
     runner = CliRunner()
-    result = runner.invoke(da_main.main, _base_args(wantlist_file))
+    result = runner.invoke(da_main.main, ["--config", str(config_file), "--once"])
     assert result.exit_code == 0, result.output
-    assert stub_loop["discogs_token"] == "TOK"
-    assert stub_loop["wantlist_path"] == str(wantlist_file)
-    assert stub_loop["alerter_type"] == "PUSHBULLET"
-    assert stub_loop["alerter_kwargs"] == {"pushbullet_token": "PB"}
-    assert stub_loop["currency"] == "EUR"
-    assert stub_loop["country"] == "Germany"
-    assert stub_loop["use_stats_gate"] is True
+    assert stub_run["run_once"] is True
+    assert stub_run["loop_kwargs"]["alerter_type"] == "NTFY"
+    assert stub_run["loop_kwargs"]["country"] == "France"
+    assert stub_run["loop_kwargs"]["currency"] == "GBP"
+    assert stub_run["cfg"].discogs_token == "TOK"
 
 
-def test_cli_requires_discogs_token(stub_loop, wantlist_file):
+def test_cli_missing_config_exits_2(tmp_path: Path):
     runner = CliRunner()
-    args = _base_args(wantlist_file)
-    args.remove("--discogs-token")
-    args.remove("TOK")
-    result = runner.invoke(da_main.main, args)
-    assert result.exit_code != 0
-    assert "discogs-token" in result.output.lower() or "DISCOGS_TOKEN" in result.output
+    result = runner.invoke(da_main.main, ["--config", str(tmp_path / "no.toml")])
+    assert result.exit_code == 2
+    assert "Invalid config" in result.output or "Config file not found" in result.output
 
 
-def test_cli_with_neither_wantlist_nor_list_id_does_not_crash_at_parse(stub_loop):
-    """Neither --list-id nor --wantlist-path is required at parse time — the
-    NotRequiredIf helpers only enforce mutual *exclusion*, not mutual *requirement*.
-    The runtime check inside `loop.load_wantlist` raises later; here we just
-    verify the CLI parses without crashing.
-    """
-
+def test_cli_validate_config_short_circuits(stub_run, config_file):
     runner = CliRunner()
-    result = runner.invoke(
-        da_main.main,
-        [
-            "--discogs-token", "TOK",
-            "--alerter-type", "PUSHBULLET",
-            "--pushbullet-token", "PB",
-            "--test",
-        ],
-    )
-    assert result.exit_code == 0
-    assert stub_loop["list_id"] is None
-    assert stub_loop["wantlist_path"] is None
+    result = runner.invoke(da_main.main, ["--config", str(config_file), "--validate-config"])
+    assert result.exit_code == 0, result.output
+    assert "Config valid" in result.output
+    assert "NTFY" in result.output
+    assert "loop_kwargs" not in stub_run
 
 
-def test_cli_telegram_requires_chat_id(stub_loop, wantlist_file):
-    """RequiredIf should fire when --alerter-type=TELEGRAM is set without
-    --telegram-chat-id (regression check for the click-8.3 UNSET bug).
-    """
+def test_cli_print_config_emits_json(stub_run, config_file):
+    runner = CliRunner()
+    result = runner.invoke(da_main.main, ["--config", str(config_file), "--print-config"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["discogs_token"] == "TOK"
+    assert payload["alerter"]["type"] == "NTFY"
+    assert payload["alerter"]["ntfy"]["topic"] == "x"
+    assert "loop_kwargs" not in stub_run
+
+
+def test_cli_verbose_flag_sets_debug_log_level(stub_run, config_file):
+    import logging
 
     runner = CliRunner()
-    result = runner.invoke(
-        da_main.main,
-        [
-            "--discogs-token", "TOK",
-            "--wantlist-path", str(wantlist_file),
-            "--alerter-type", "TELEGRAM",
-            "--telegram-token", "TG",
-            "--test",
-        ],
-    )
-    assert result.exit_code != 0
-    assert "telegram_chat_id" in result.output or "is required" in result.output
+    result = runner.invoke(da_main.main, ["--config", str(config_file), "--once", "--verbose"])
+    assert result.exit_code == 0, result.output
+    assert logging.getLogger().level == logging.DEBUG
+    assert stub_run["loop_kwargs"]["verbose"] is True
 
 
-def test_cli_ntfy_requires_topic(stub_loop, wantlist_file):
+def test_cli_log_level_override(stub_run, config_file):
+    import logging
+
     runner = CliRunner()
     result = runner.invoke(
-        da_main.main,
-        [
-            "--discogs-token", "TOK",
-            "--wantlist-path", str(wantlist_file),
-            "--alerter-type", "NTFY",
-            "--test",
-        ],
-    )
-    assert result.exit_code != 0
-    assert "ntfy_topic" in result.output or "is required" in result.output
-
-
-def test_cli_ntfy_happy_path(stub_loop, wantlist_file):
-    runner = CliRunner()
-    result = runner.invoke(
-        da_main.main,
-        [
-            "--discogs-token", "TOK",
-            "--wantlist-path", str(wantlist_file),
-            "--alerter-type", "NTFY",
-            "--ntfy-topic", "my-topic",
-            "--test",
-        ],
+        da_main.main, ["--config", str(config_file), "--once", "--log-level", "WARNING"]
     )
     assert result.exit_code == 0, result.output
-    assert stub_loop["alerter_type"] == "NTFY"
-    assert stub_loop["alerter_kwargs"] == {
-        "ntfy_topic": "my-topic",
-        "ntfy_server": "https://ntfy.sh",
-        "ntfy_token": None,
-    }
+    assert logging.getLogger().level == logging.WARNING
 
 
-def test_cli_telegram_happy_path(stub_loop, wantlist_file):
+def test_cli_log_level_invalid_value_rejected(config_file):
     runner = CliRunner()
     result = runner.invoke(
-        da_main.main,
-        [
-            "--discogs-token", "TOK",
-            "--wantlist-path", str(wantlist_file),
-            "--alerter-type", "TELEGRAM",
-            "--telegram-token", "TG",
-            "--telegram-chat-id", "42",
-            "--test",
-        ],
-    )
-    assert result.exit_code == 0, result.output
-    assert stub_loop["alerter_type"] == "TELEGRAM"
-    assert stub_loop["alerter_kwargs"] == {"telegram_token": "TG", "telegram_chat_id": "42"}
-
-
-def test_cli_passes_filters_through(stub_loop, wantlist_file):
-    runner = CliRunner()
-    result = runner.invoke(
-        da_main.main,
-        _base_args(wantlist_file)
-        + [
-            "--min-media-condition", "NEAR_MINT",
-            "--min-sleeve-condition", "VERY_GOOD",
-            "--min-seller-rating", "98",
-            "--country", "France",
-            "--currency", "GBP",
-        ],
-    )
-    assert result.exit_code == 0, result.output
-    assert stub_loop["country"] == "France"
-    assert stub_loop["currency"] == "GBP"
-    assert stub_loop["seller_filters"].min_seller_rating == 98
-    assert stub_loop["record_filters"].min_media_condition == da_entities.CONDITION.NEAR_MINT
-    assert stub_loop["record_filters"].min_sleeve_condition == da_entities.CONDITION.VERY_GOOD
-
-
-def test_cli_country_whitelist_and_blacklist(stub_loop, wantlist_file):
-    runner = CliRunner()
-    result = runner.invoke(
-        da_main.main,
-        _base_args(wantlist_file) + ["-wl", "DE", "-wl", "FR", "-bl", "UK"],
-    )
-    assert result.exit_code == 0, result.output
-    assert stub_loop["country_whitelist"] == {"Germany", "France"}
-    assert stub_loop["country_blacklist"] == {"United Kingdom"}
-
-
-def test_cli_no_stats_gate_flag(stub_loop, wantlist_file):
-    runner = CliRunner()
-    result = runner.invoke(da_main.main, _base_args(wantlist_file) + ["--no-stats-gate"])
-    assert result.exit_code == 0, result.output
-    assert stub_loop["use_stats_gate"] is False
-
-
-def test_cli_state_path_passes_through(stub_loop, wantlist_file, tmp_path):
-    db = tmp_path / "x.db"
-    runner = CliRunner()
-    result = runner.invoke(da_main.main, _base_args(wantlist_file) + ["--state-path", str(db)])
-    assert result.exit_code == 0, result.output
-    assert stub_loop["state_path"] == str(db)
-
-
-def test_cli_once_flag_runs_loop_once(stub_loop, wantlist_file):
-    """`--once` should invoke `loop` exactly once and skip the schedule path."""
-
-    runner = CliRunner()
-    args = _base_args(wantlist_file)
-    # _base_args already includes --test (the legacy alias for --once); replace
-    # it with the canonical flag so we exercise that path.
-    args.remove("--test")
-    args.append("--once")
-    result = runner.invoke(da_main.main, args)
-    assert result.exit_code == 0, result.output
-
-
-def test_cli_log_level_flag_propagates(stub_loop, wantlist_file, monkeypatch):
-    import logging as stdlogging
-
-    runner = CliRunner()
-    result = runner.invoke(
-        da_main.main, _base_args(wantlist_file) + ["--log-level", "WARNING"]
-    )
-    assert result.exit_code == 0, result.output
-    # Root logger level should now be WARNING.
-    assert stdlogging.getLogger().level == stdlogging.WARNING
-
-
-def test_cli_log_level_invalid_value_rejected(stub_loop, wantlist_file):
-    runner = CliRunner()
-    result = runner.invoke(
-        da_main.main, _base_args(wantlist_file) + ["--log-level", "TRACE"]
-    )
-    assert result.exit_code != 0
-
-
-def test_cli_prune_after_days_default(stub_loop, wantlist_file):
-    runner = CliRunner()
-    result = runner.invoke(da_main.main, _base_args(wantlist_file))
-    assert result.exit_code == 0, result.output
-    assert stub_loop["prune_after_days"] == 90
-
-
-def test_cli_prune_after_days_override(stub_loop, wantlist_file):
-    runner = CliRunner()
-    result = runner.invoke(da_main.main, _base_args(wantlist_file) + ["--prune-after-days", "0"])
-    assert result.exit_code == 0, result.output
-    assert stub_loop["prune_after_days"] == 0
-
-
-def test_cli_list_id_and_wantlist_path_mutual_exclusion(stub_loop, wantlist_file):
-    runner = CliRunner()
-    result = runner.invoke(
-        da_main.main,
-        [
-            "--discogs-token", "TOK",
-            "--list-id", "42",
-            "--wantlist-path", str(wantlist_file),
-            "--alerter-type", "PUSHBULLET",
-            "--pushbullet-token", "PB",
-            "--test",
-        ],
-    )
-    assert result.exit_code != 0
-    assert "mutually exclusive" in result.output
-
-
-def test_cli_unknown_currency_rejected(stub_loop, wantlist_file):
-    runner = CliRunner()
-    result = runner.invoke(
-        da_main.main, _base_args(wantlist_file) + ["--currency", "XYZ"]
+        da_main.main, ["--config", str(config_file), "--log-level", "TRACE"]
     )
     assert result.exit_code != 0
 
@@ -296,3 +139,86 @@ def test_cli_version_flag_works():
     result = runner.invoke(da_main.main, ["--version"])
     assert result.exit_code == 0
     assert "version" in result.output.lower()
+
+
+def test_cli_env_vars_override_config_file(stub_run, config_file, monkeypatch):
+    monkeypatch.setenv("DA_DISCOGS_TOKEN", "FROM_ENV")
+    runner = CliRunner()
+    result = runner.invoke(da_main.main, ["--config", str(config_file), "--once"])
+    assert result.exit_code == 0, result.output
+    assert stub_run["cfg"].discogs_token == "FROM_ENV"
+
+
+def test_cli_config_via_env_var(stub_run, config_file, monkeypatch):
+    monkeypatch.setenv("DA_CONFIG_PATH", str(config_file))
+    runner = CliRunner()
+    result = runner.invoke(da_main.main, ["--once"])
+    assert result.exit_code == 0, result.output
+    assert stub_run["loop_kwargs"]["alerter_type"] == "NTFY"
+
+
+# -- _build_loop_kwargs (unit) ----------------------------------------------
+
+
+def test_build_loop_kwargs_pushbullet():
+    from discogs_alert import config as da_config
+
+    cfg = da_config.Config.model_validate(
+        {
+            "discogs_token": "T",
+            "alerter": {"type": "PUSHBULLET", "pushbullet": {"token": "PB"}},
+            "wantlist": {"path": "/x"},
+        }
+    )
+    kw = da_main._build_loop_kwargs(cfg)
+    assert kw["alerter_type"] == "PUSHBULLET"
+    assert kw["alerter_kwargs"] == {"pushbullet_token": "PB"}
+    assert kw["wantlist_path"] == "/x"
+
+
+def test_build_loop_kwargs_country_filters():
+    from discogs_alert import config as da_config
+
+    cfg = da_config.Config.model_validate(
+        {
+            "discogs_token": "T",
+            "country_filters": {"whitelist": ["DE"], "blacklist": ["UK", "US"]},
+        }
+    )
+    kw = da_main._build_loop_kwargs(cfg)
+    assert kw["country_whitelist"] == {"Germany"}
+    assert kw["country_blacklist"] == {"United Kingdom", "United States"}
+
+
+# -- _run (unit) ------------------------------------------------------------
+
+
+async def test_run_invokes_loop_once_when_run_once_true(monkeypatch: pytest.MonkeyPatch):
+    """Once-mode should call `loop.loop` exactly once and tear the clients down."""
+
+    from unittest.mock import AsyncMock, MagicMock
+
+    from discogs_alert import client as da_client, config as da_config, loop as da_loop
+
+    fake_anon = MagicMock()
+    fake_anon.aclose = AsyncMock()
+    fake_user = MagicMock()
+    fake_user.aclose = AsyncMock()
+    monkeypatch.setattr(da_client, "AnonClient", lambda *_a, **_kw: fake_anon)
+    monkeypatch.setattr(da_client, "UserTokenClient", lambda *_a, **_kw: fake_user)
+
+    loop_calls: list = []
+
+    async def fake_loop(**kwargs):
+        loop_calls.append(kwargs)
+
+    monkeypatch.setattr(da_loop, "loop", fake_loop)
+
+    cfg = da_config.Config.model_validate({"discogs_token": "T"})
+    await da_main._run(
+        loop_kwargs={"discogs_token": "T"}, run_once=True, interval_seconds=1, cfg=cfg
+    )
+
+    assert len(loop_calls) == 1
+    fake_anon.aclose.assert_awaited_once()
+    fake_user.aclose.assert_awaited_once()


### PR DESCRIPTION
## Summary
The 25-flag click command was a wall of bureaucracy that mostly existed to round-trip values into env vars and back out into kwargs. With the pydantic schema + TOML loader from #125 (Phase A) in place, the CLI shrinks dramatically:

\`\`\`
-c / --config <path>       — TOML config file (default ~/.discogs_alert/config.toml)
-O / --once                — run once and exit (cron / launchd / systemd)
-V / --verbose             — shortcut for --log-level=DEBUG + runtime.verbose=true
-l / --log-level           — explicit root log level
--validate-config          — load + validate, print summary, exit 0
--print-config             — load + dump resolved values as JSON, exit 0
--version
\`\`\`

Everything else lives in the TOML file or \`DA_*\` env vars (Docker / launchd / CI workflows still work — the mapping is in \`discogs_alert.config._ENV_OVERRIDES\`).

## What ships

- New \`examples/config.example.toml\` (heavily annotated).
- \`tests/test_main.py\` rewritten — 13 focused tests around the load → flag → run pipeline.
- **Pre-commit hooks beefed up**: ruff bumped to 0.6.9 (was 0.0.249, four years stale) and a local \`pytest -m "not online"\` hook so lint / test failures surface before push. Coverage gating stays in CI (slower).

## Test plan
- [x] 245 tests pass, coverage 88.22%.
- [x] \`ruff check discogs_alert tests examples\` clean locally.
- [x] \`--validate-config\` and \`--print-config\` exercise the load path; \`--version\` works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)