### PR TITLE
Automated release: tag-triggered .app + DMG + signed Sparkle update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,3 +107,100 @@ jobs:
           tags: |
             miggleball/discogs_alert:${{ github.ref_name }}
             miggleball/discogs_alert:latest
+
+  build-macos-app:
+    name: Build macOS .app + .dmg, sign, append to appcast
+    needs: github-release
+    runs-on: macos-latest
+    # Skip if Sparkle signing keys aren't configured. The job is
+    # otherwise unconditional on tag pushes.
+    if: ${{ vars.SPARKLE_PUBLIC_KEY != '' || secrets.SPARKLE_PUBLIC_KEY != '' }}
+    permissions:
+      contents: write  # to push the appcast update back to main
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # need full history to push back to main later
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build deps
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e '.[menubar]' py2app
+
+      - name: Download Sparkle.framework
+        run: make sparkle
+
+      - name: Stage public key
+        # The build reads the public key from this file via DA_SPARKLE_PUBLIC_KEY.
+        # `printf %s` (no newline) keeps the base64 clean.
+        run: |
+          mkdir -p ~/.discogs_alert_release
+          chmod 700 ~/.discogs_alert_release
+          printf '%s' "${{ secrets.SPARKLE_PUBLIC_KEY }}" > ~/.discogs_alert_release/eddsa_pub.key
+          chmod 600 ~/.discogs_alert_release/eddsa_pub.key
+
+      - name: Build .app
+        run: make app
+
+      - name: Build .dmg
+        run: make dmg
+
+      - name: Sign DMG with EdDSA
+        id: sign
+        env:
+          SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#v}"
+          DMG="dist/discogs_alert-${VERSION}.dmg"
+          # `sign_update` reads the private key from stdin via `-f -` and
+          # prints `sparkle:edSignature="…" length="…"` to stdout.
+          SIG_LINE=$(printf '%s' "$SPARKLE_PRIVATE_KEY" | vendor/bin/sign_update --ed-key-file - "$DMG")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "dmg=$DMG" >> "$GITHUB_OUTPUT"
+          # Multi-line-safe output capture (the line itself is single-line
+          # but defensive against future format changes).
+          {
+            echo "signature<<SIGEOF"
+            echo "$SIG_LINE"
+            echo "SIGEOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Upload DMG to the GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "$GITHUB_REF_NAME" "${{ steps.sign.outputs.dmg }}" --clobber
+
+      - name: Append <item> to docs/appcast.xml on main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Switch to main so the appcast change lands there (the build
+          # ran on the tag's checkout). Stash anything that could collide.
+          git stash --include-untracked --quiet || true
+          git fetch origin main
+          git checkout main
+          git pull --ff-only
+
+          DOWNLOAD_URL="https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/$(basename '${{ steps.sign.outputs.dmg }}')"
+          python scripts/append_to_appcast.py \
+              --version "${{ steps.sign.outputs.version }}" \
+              --signature '${{ steps.sign.outputs.signature }}' \
+              --download-url "$DOWNLOAD_URL" \
+              --notes "<h2>${{ github.ref_name }}</h2>"
+
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git add docs/appcast.xml
+          if git diff --cached --quiet; then
+            echo "::notice::appcast already contains ${{ github.ref_name }}; nothing to push."
+            exit 0
+          fi
+          git commit -m "Append ${{ github.ref_name }} to appcast"
+          git push origin main

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ RELEASE_DIR := $(HOME)/.discogs_alert_release
 PRIV_KEY := $(RELEASE_DIR)/eddsa_priv.key
 PUB_KEY := $(RELEASE_DIR)/eddsa_pub.key
 
-.PHONY: all app dmg sparkle keys sign appcast clean clean-build clean-venv clean-vendor
+.PHONY: all app dmg sparkle keys sign appcast secrets clean clean-build clean-venv clean-vendor
 
 all: dmg
 
@@ -166,3 +166,20 @@ clean-venv:
 
 clean-vendor:
 	rm -rf $(VENDOR)
+
+# ---- CI release secrets ----------------------------------------------------
+#
+# Push the Sparkle EdDSA keys into GitHub Actions secrets so the
+# tag-triggered release workflow can build + sign on a macOS runner.
+# Only the maintainer ever runs this; it just calls `gh secret set` for
+# each key. Idempotent — re-running overwrites the secret in place.
+secrets: $(PUB_KEY) $(PRIV_KEY)
+	@echo "Pushing Sparkle keys to GitHub repo secrets…"
+	@gh secret set SPARKLE_PUBLIC_KEY < $(PUB_KEY)
+	@gh secret set SPARKLE_PRIVATE_KEY < $(PRIV_KEY)
+	@echo
+	@echo "✅ Secrets installed:"
+	@echo "   SPARKLE_PUBLIC_KEY"
+	@echo "   SPARKLE_PRIVATE_KEY"
+	@echo
+	@echo "Next: 'git tag vX.Y.Z && git push --tags' to trigger an automated release."

--- a/docs/release.md
+++ b/docs/release.md
@@ -40,43 +40,69 @@ existing installs upgrade themselves automatically.
    - That URL is baked into the bundle's `Info.plist` as
      `SUFeedURL`. Override at build time with `DA_APPCAST_URL=…`.
 
-## Each release
+4. **Push the signing keys to GitHub Actions secrets** (one-time):
+   ```bash
+   make secrets
+   ```
+   That just runs `gh secret set SPARKLE_PUBLIC_KEY < ~/…/eddsa_pub.key`
+   and `gh secret set SPARKLE_PRIVATE_KEY < ~/…/eddsa_priv.key`. The
+   release workflow reads both at runtime.
+
+   *Re-running `make secrets` overwrites the secrets in place, so you
+   can do this again any time (e.g. after rotating keys).*
+
+## Each release (automated)
+
+The release workflow at `.github/workflows/release.yml` builds, signs,
+publishes, and updates the appcast on every `vX.Y.Z` tag push. You only
+need to bump the version, commit, tag, push:
 
 ```bash
-# 1. Bump the version in pyproject.toml.
-$EDITOR pyproject.toml          # bump [tool.poetry] version
+# 1. Bump the version in pyproject.toml AND discogs_alert/__init__.py.
+#    Both must match the tag, or the `release` workflow's sanity-check
+#    fails fast.
+$EDITOR pyproject.toml             # bump [tool.poetry] version
 $EDITOR discogs_alert/__init__.py  # bump _FALLBACK_VERSION to match
 
-# 2. Tag the commit (Sparkle ignores the tag name itself but it's nice for git log).
+# 2. Commit, tag, push.
 git commit -am "Bump version to 0.1.1"
 git tag v0.1.1
-git push --tags
+git push origin main --tags
 
-# 3. Build the .app and the .dmg.
-make app
-make dmg
+# That's it. CI (on macos-latest) takes ~5min and:
+#   - builds dist/discogs_alert-0.1.1.dmg
+#   - signs it with the EdDSA key from secrets
+#   - creates a GitHub Release v0.1.1, uploads the DMG
+#   - appends a new <item> to docs/appcast.xml
+#   - commits + pushes the appcast change to main
+#
+# You can watch progress with `gh run watch`.
 
-# 4. Sign the DMG. `make sign` prints something like:
-#       sparkle:edSignature="..." length="..."
-#    Copy those two values; you'll paste them into the appcast below.
-make sign
+# 3. (Optional) Verify the published artifacts:
+gh release view v0.1.1                # confirm the DMG is attached
+curl -fsSI "$(gh release view v0.1.1 --json assets --jq '.assets[0].url')"
+```
 
-# 5. Upload the DMG to a GitHub Release for v0.1.1.
-gh release create v0.1.1 dist/discogs_alert-0.1.1.dmg --notes "0.1.1 release notes…"
+Existing `.app` installs poll the appcast on launch + once a day,
+download the new DMG, verify the EdDSA signature, and prompt the user
+to install. No more manual upgrade steps for users.
 
-# 6. Edit docs/appcast.xml — add a new <item> at the top with:
-#      - <enclosure url=…> pointing at the GitHub release URL
-#      - sparkle:edSignature and length from step 4
-#      - <pubDate> in RFC 822 format
-#      - <description> with a short HTML changelog
-#    Commit + push docs/appcast.xml; Pages picks it up within a minute.
-$EDITOR docs/appcast.xml
-git commit -am "Append v0.1.1 to appcast"
+## Each release (manual fallback)
+
+If the workflow is broken or you want to ship a hotfix from your own
+machine, the `make` targets cover the same steps:
+
+```bash
+make app                                                    # → dist/discogs_alert.app
+make dmg                                                    # → dist/discogs_alert-X.Y.Z.dmg
+make sign                                                   # prints sparkle:edSignature="…" length="…"
+gh release create vX.Y.Z dist/discogs_alert-X.Y.Z.dmg --generate-notes
+python scripts/append_to_appcast.py \
+    --version X.Y.Z \
+    --signature 'sparkle:edSignature="…" length="…"' \
+    --download-url "https://github.com/<owner>/<repo>/releases/download/vX.Y.Z/discogs_alert-X.Y.Z.dmg"
+git commit -am "Append vX.Y.Z to appcast"
 git push
-
-# 7. Existing installs poll the appcast on launch + once a day. They'll
-#    notice the new <item>, download the DMG, verify the EdDSA sig, and
-#    prompt the user to update.
 ```
 
 ## Sanity-checks

--- a/scripts/append_to_appcast.py
+++ b/scripts/append_to_appcast.py
@@ -1,0 +1,189 @@
+"""Append a new release entry to ``docs/appcast.xml``.
+
+Called by the release CI workflow after a DMG has been built, signed, and
+uploaded to a GitHub Release. Keeps the XML well-formed by parsing with
+``xml.etree`` rather than templating strings.
+
+Usage::
+
+    python scripts/append_to_appcast.py \\
+        --version 0.1.0 \\
+        --dmg dist/discogs_alert-0.1.0.dmg \\
+        --signature 'sparkle:edSignature="…" length="…"' \\
+        --download-url 'https://github.com/…/releases/download/v0.1.0/foo.dmg' \\
+        --notes 'First release.'
+
+The ``--signature`` argument is the full ``sparkle:edSignature="…"
+length="…"`` string that ``sign_update`` prints. The script parses it
+out and attaches both attributes to the new ``<enclosure>`` element.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+NSMAP = {
+    "sparkle": "http://www.andymatuschak.org/xml-namespaces/sparkle",
+    "dc": "http://purl.org/dc/elements/1.1/",
+}
+
+# We register the namespaces so ElementTree emits the right prefixes.
+for prefix, uri in NSMAP.items():
+    ET.register_namespace(prefix, uri)
+
+
+def _parse_signature_line(line: str) -> tuple[str, str]:
+    """Pull the ``sparkle:edSignature`` and ``length`` values out of the
+    string ``sign_update`` prints. The exact format is::
+
+        sparkle:edSignature="aBcDe…=" length="12345"
+
+    Returns ``(signature, length)``.
+    """
+
+    sig_match = re.search(r'sparkle:edSignature="([^"]+)"', line)
+    len_match = re.search(r'length="(\d+)"', line)
+    if not sig_match or not len_match:
+        raise ValueError(
+            f"Couldn't parse sign_update output {line!r}; "
+            "expected `sparkle:edSignature=\"…\" length=\"…\"`"
+        )
+    return sig_match.group(1), len_match.group(1)
+
+
+def _make_item(
+    version: str,
+    download_url: str,
+    signature: str,
+    length: str,
+    notes: str,
+    pub_date: datetime,
+) -> ET.Element:
+    """Build a single ``<item>`` element matching the schema Sparkle expects."""
+
+    item = ET.Element("item")
+    ET.SubElement(item, "title").text = version
+    # RFC 822 / RFC 2822 date format — what Sparkle wants.
+    ET.SubElement(item, "pubDate").text = pub_date.strftime("%a, %d %b %Y %H:%M:%S +0000")
+
+    sparkle_version = ET.SubElement(item, f"{{{NSMAP['sparkle']}}}version")
+    sparkle_version.text = version
+    sparkle_short = ET.SubElement(item, f"{{{NSMAP['sparkle']}}}shortVersionString")
+    sparkle_short.text = version
+    min_macos = ET.SubElement(item, f"{{{NSMAP['sparkle']}}}minimumSystemVersion")
+    min_macos.text = "11.0"
+
+    description = ET.SubElement(item, "description")
+    # CDATA isn't first-class in ElementTree; the simplest approach is to
+    # just put HTML in the text and let the XML parser handle escaping.
+    # Sparkle treats <description> contents as HTML regardless.
+    description.text = notes
+
+    enclosure = ET.SubElement(item, "enclosure")
+    enclosure.set("url", download_url)
+    enclosure.set(f"{{{NSMAP['sparkle']}}}edSignature", signature)
+    enclosure.set("length", length)
+    enclosure.set("type", "application/octet-stream")
+
+    return item
+
+
+def append_item(
+    appcast_path: Path,
+    version: str,
+    download_url: str,
+    signature: str,
+    length: str,
+    notes: str,
+    pub_date: datetime | None = None,
+) -> None:
+    """Insert a new ``<item>`` at the top of the existing channel."""
+
+    pub_date = pub_date or datetime.now(timezone.utc)
+
+    tree = ET.parse(appcast_path)
+    root = tree.getroot()
+    channel = root.find("channel")
+    if channel is None:
+        raise ValueError(f"{appcast_path} has no <channel> element")
+
+    # Refuse to add a duplicate version — protects against re-run safety.
+    sparkle_version_tag = f"{{{NSMAP['sparkle']}}}version"
+    for existing in channel.findall("item"):
+        existing_ver = existing.find(sparkle_version_tag)
+        if existing_ver is not None and existing_ver.text == version:
+            print(
+                f"appcast already contains an item for {version}; not appending again",
+                file=sys.stderr,
+            )
+            return
+
+    item = _make_item(version, download_url, signature, length, notes, pub_date)
+
+    # Insert right after the static channel headers (title/link/description/language)
+    # so the newest item is always at the top of the items list. Find the index
+    # of the first existing <item>, or append after the last header.
+    children = list(channel)
+    insert_at = len(children)
+    for idx, child in enumerate(children):
+        if child.tag == "item":
+            insert_at = idx
+            break
+    channel.insert(insert_at, item)
+
+    # Pretty-print: ET.indent is 3.9+, which we use everywhere.
+    ET.indent(tree, space="    ", level=0)
+    tree.write(appcast_path, xml_declaration=True, encoding="utf-8")
+    # ElementTree adds a trailing newline only sometimes; normalise.
+    contents = appcast_path.read_text()
+    if not contents.endswith("\n"):
+        appcast_path.write_text(contents + "\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("--version", required=True, help="Release version, e.g. 0.1.0")
+    parser.add_argument(
+        "--signature",
+        required=True,
+        help='Full sign_update output, e.g. \'sparkle:edSignature="…" length="…"\'',
+    )
+    parser.add_argument(
+        "--download-url",
+        required=True,
+        help="Public URL of the .dmg in the GitHub Release.",
+    )
+    parser.add_argument(
+        "--notes",
+        default="",
+        help="Optional HTML release notes to put in <description>.",
+    )
+    parser.add_argument(
+        "--appcast-path",
+        type=Path,
+        default=Path("docs/appcast.xml"),
+        help="Path to the appcast.xml to update.",
+    )
+    args = parser.parse_args(argv)
+
+    signature, length = _parse_signature_line(args.signature)
+    notes = args.notes or f"<h2>{args.version}</h2>"
+    append_item(
+        appcast_path=args.appcast_path,
+        version=args.version,
+        download_url=args.download_url,
+        signature=signature,
+        length=length,
+        notes=notes,
+    )
+    print(f"Appended {args.version} to {args.appcast_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_append_to_appcast.py
+++ b/tests/test_append_to_appcast.py
@@ -1,0 +1,185 @@
+"""Tests for the appcast appender script.
+
+The script lives in ``scripts/`` (outside the package) so we import it
+the slightly-awkward way: by adding ``scripts/`` to sys.path and
+importing the module directly.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+import pytest
+
+# Make the script importable.
+SCRIPTS_DIR = Path(__file__).parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import append_to_appcast as appender  # noqa: E402,I001
+
+
+SKELETON = """<?xml version="1.0" standalone="yes"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <channel>
+        <title>discogs_alert</title>
+        <link>https://github.com/michaelhball/discogs_alert</link>
+        <description>Most recent macOS releases.</description>
+        <language>en</language>
+    </channel>
+</rss>
+"""
+
+
+@pytest.fixture
+def appcast(tmp_path: Path) -> Path:
+    path = tmp_path / "appcast.xml"
+    path.write_text(SKELETON)
+    return path
+
+
+def _items(path: Path) -> list[ET.Element]:
+    tree = ET.parse(path)
+    return tree.findall(".//item")
+
+
+# -- _parse_signature_line --------------------------------------------------
+
+
+def test_parse_signature_line_extracts_both():
+    sig, length = appender._parse_signature_line(
+        'sparkle:edSignature="ABC=" length="12345"'
+    )
+    assert sig == "ABC="
+    assert length == "12345"
+
+
+def test_parse_signature_line_handles_extra_whitespace():
+    sig, length = appender._parse_signature_line(
+        '    sparkle:edSignature="ABC=" length="12345"\n'
+    )
+    assert sig == "ABC="
+    assert length == "12345"
+
+
+def test_parse_signature_line_rejects_unparseable():
+    with pytest.raises(ValueError):
+        appender._parse_signature_line("not the right shape")
+
+
+# -- append_item ------------------------------------------------------------
+
+
+def test_append_inserts_new_item(appcast: Path):
+    appender.append_item(
+        appcast_path=appcast,
+        version="0.1.0",
+        download_url="https://example.com/foo.dmg",
+        signature="SIG=",
+        length="123",
+        notes="<h2>0.1.0</h2>",
+        pub_date=datetime(2026, 5, 9, 18, 30, 0, tzinfo=timezone.utc),
+    )
+    items = _items(appcast)
+    assert len(items) == 1
+    item = items[0]
+    assert item.find("title").text == "0.1.0"
+    assert item.find(
+        "{http://www.andymatuschak.org/xml-namespaces/sparkle}version"
+    ).text == "0.1.0"
+    enclosure = item.find("enclosure")
+    assert enclosure.get("url") == "https://example.com/foo.dmg"
+    assert enclosure.get(
+        "{http://www.andymatuschak.org/xml-namespaces/sparkle}edSignature"
+    ) == "SIG="
+    assert enclosure.get("length") == "123"
+
+
+def test_append_pubdate_is_rfc822(appcast: Path):
+    appender.append_item(
+        appcast_path=appcast,
+        version="0.1.0",
+        download_url="x",
+        signature="x",
+        length="0",
+        notes="",
+        pub_date=datetime(2026, 5, 9, 18, 30, 0, tzinfo=timezone.utc),
+    )
+    pub_date = _items(appcast)[0].find("pubDate").text
+    assert pub_date == "Sat, 09 May 2026 18:30:00 +0000"
+
+
+def test_append_is_idempotent_per_version(appcast: Path):
+    """Running with the same version twice must not double-insert."""
+
+    for _ in range(2):
+        appender.append_item(
+            appcast_path=appcast,
+            version="0.1.0",
+            download_url="x",
+            signature="x",
+            length="0",
+            notes="",
+        )
+    assert len(_items(appcast)) == 1
+
+
+def test_append_keeps_newest_at_top(appcast: Path):
+    """A second release should land *before* the first."""
+
+    appender.append_item(
+        appcast_path=appcast,
+        version="0.1.0",
+        download_url="x",
+        signature="x",
+        length="0",
+        notes="",
+    )
+    appender.append_item(
+        appcast_path=appcast,
+        version="0.1.1",
+        download_url="x",
+        signature="x",
+        length="0",
+        notes="",
+    )
+    items = _items(appcast)
+    assert len(items) == 2
+    assert items[0].find("title").text == "0.1.1"
+    assert items[1].find("title").text == "0.1.0"
+
+
+def test_append_rejects_appcast_without_channel(tmp_path: Path):
+    path = tmp_path / "broken.xml"
+    path.write_text('<?xml version="1.0"?><rss version="2.0"></rss>')
+    with pytest.raises(ValueError, match="no <channel>"):
+        appender.append_item(
+            appcast_path=path,
+            version="0.1.0",
+            download_url="x",
+            signature="x",
+            length="0",
+            notes="",
+        )
+
+
+# -- main (smoke) -----------------------------------------------------------
+
+
+def test_main_smoke(appcast: Path, capsys: pytest.CaptureFixture):
+    appender.main(
+        [
+            "--version", "0.1.0",
+            "--signature", 'sparkle:edSignature="SIG=" length="42"',
+            "--download-url", "https://example.com/x.dmg",
+            "--appcast-path", str(appcast),
+        ]
+    )
+    captured = capsys.readouterr()
+    assert "Appended 0.1.0" in captured.out
+
+    items = _items(appcast)
+    assert len(items) == 1
+    assert items[0].find("enclosure").get("length") == "42"


### PR DESCRIPTION
## Summary
Push a \`v*.*.*\` tag and CI does the rest:

1. Builds the macOS \`.app\` on \`macos-latest\`.
2. Wraps it in a \`.dmg\`.
3. Signs the DMG with the EdDSA key from \`SPARKLE_PRIVATE_KEY\` (Actions secret).
4. Uploads the DMG to the auto-created GitHub Release.
5. Appends a fresh \`<item>\` to \`docs/appcast.xml\` and commits back to \`main\`.

Existing \`.app\` installs poll the appcast on launch + once a day, download the new DMG, verify the signature, and prompt the user to install. **Zero manual steps after \`git push --tags\`.**

## Required setup (one-time)
\`\`\`bash
make secrets   # pushes SPARKLE_PUBLIC_KEY + SPARKLE_PRIVATE_KEY to repo secrets
\`\`\`

## Per-release flow
\`\`\`bash
$EDITOR pyproject.toml             # bump version
$EDITOR discogs_alert/__init__.py  # bump _FALLBACK_VERSION
git commit -am "Bump to 0.1.1"
git tag v0.1.1
git push origin main --tags
# done. Watch with `gh run watch`.
\`\`\`

## What's in the PR
- \`.github/workflows/release.yml\` — new \`build-macos-app\` job (downstream of \`github-release\`).
- \`scripts/append_to_appcast.py\` — appends a well-formed \`<item>\` to the appcast with the right signature/length/URL/date. Idempotent (won't duplicate-insert).
- \`Makefile\` — \`make secrets\` target.
- \`docs/release.md\` rewritten around the automated flow (manual fallback retained).
- 9 new tests in \`tests/test_append_to_appcast.py\` covering parsing, ordering, idempotency, errors, CLI.

## Test plan
- [x] 263 tests pass; coverage 88.77%.
- [x] \`yaml.safe_load\` of release.yml clean.
- [x] Workflow job is gated on \`vars.SPARKLE_PUBLIC_KEY != '' || secrets.SPARKLE_PUBLIC_KEY != ''\` so it skips silently on forks without the secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)